### PR TITLE
Make tags chips more visible

### DIFF
--- a/frontend/.prettierrc
+++ b/frontend/.prettierrc
@@ -8,14 +8,7 @@
   "bracketSpacing": true,
   "arrowParens": "always",
   "endOfLine": "lf",
-  "importOrder": [
-    "^react(.*)$",
-    "^@mui/(.*)$",
-    "^@reduxjs/(.*)$",
-    "<THIRD_PARTY_MODULES>",
-    "^@custom-widgets/(.*)$",
-    "^[./]"
-  ],
+  "importOrder": ["^react(.*)$", "^@mui/(.*)$", "^@reduxjs/(.*)$", "<THIRD_PARTY_MODULES>", "^@custom-widgets/(.*)$", "^[./]"],
   "importOrderSeparation": true,
   "importOrderSortSpecifiers": true,
   "overrides": [

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -9,10 +9,7 @@
     <link rel="apple-touch-icon" href="/logo192.png" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link
-      href="https://fonts.googleapis.com/css2?family=Montserrat&display=swap"
-      rel="stylesheet"
-    />
+    <link href="https://fonts.googleapis.com/css2?family=Montserrat&display=swap" rel="stylesheet" />
     <link rel="manifest" href="/manifest.json" />
     <title>Article Manager</title>
   </head>

--- a/frontend/src/components/forms/TagsForm.tsx
+++ b/frontend/src/components/forms/TagsForm.tsx
@@ -39,7 +39,7 @@ function TagsForm({ onChange, currentTags }: Readonly<TagsProps>) {
       </label>
       <div className="tags-input-wrapper flex flex-wrap items-center gap-2 rounded border border-gray-300 bg-white p-2 dark:border-slate-600 dark:bg-slate-800">
         {tags.map((tag, index) => (
-          <div className="tag-chip flex flex-row items-center space-x-2 rounded-full px-3 py-2 dark:bg-slate-700" key={tag}>
+          <div className="tag-chip flex flex-row items-center space-x-2 rounded-full bg-slate-200 px-3 py-2 dark:bg-slate-700" key={tag}>
             <span className="text-slate-800 dark:text-slate-100" onKeyDown={() => removeTag(index)}>
               {tag}
             </span>

--- a/frontend/src/components/layout/PageHeader.tsx
+++ b/frontend/src/components/layout/PageHeader.tsx
@@ -1,4 +1,4 @@
-import { ReactNode } from "react";
+import { ReactNode } from 'react';
 
 interface PageHeaderProps {
   title: string;
@@ -9,9 +9,7 @@ interface PageHeaderProps {
 function PageHeader({ title, description, children }: Readonly<PageHeaderProps>) {
   return (
     <div className="rounded-2xl border border-slate-200/80 bg-white/90 p-5 shadow-sm transition-colors dark:border-slate-700 dark:bg-slate-800/80">
-      <h2 className="text-2xl font-bold tracking-tight text-slate-900 dark:text-slate-100">
-        {title}
-      </h2>
+      <h2 className="text-2xl font-bold tracking-tight text-slate-900 dark:text-slate-100">{title}</h2>
       <p className="mt-1 text-sm text-slate-600 dark:text-slate-300">{description}</p>
       {children ? <div className="mt-3">{children}</div> : null}
     </div>

--- a/frontend/tailwind.config.cjs
+++ b/frontend/tailwind.config.cjs
@@ -1,7 +1,7 @@
 /** @type {import('tailwindcss').Config} */
 module.exports = {
-  darkMode: "class",
-  content: ["./index.html", "./src/**/*.{js,jsx,ts,tsx}"],
+  darkMode: 'class',
+  content: ['./index.html', './src/**/*.{js,jsx,ts,tsx}'],
   theme: {
     extend: {},
   },

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,5 +1,5 @@
-import { defineConfig } from "vitest/config";
-import react from "@vitejs/plugin-react";
+import { defineConfig } from 'vitest/config';
+import react from '@vitejs/plugin-react';
 
 export default defineConfig({
   plugins: [react()],


### PR DESCRIPTION
## Description

Add a light background to tags chips in the Article form to make them more visible in light mode.


Closes #3