### PR TITLE
feat(frontend): add eye icon to toggle password visibility

### DIFF
--- a/frontend/src/components/forms/AuthForm.tsx
+++ b/frontend/src/components/forms/AuthForm.tsx
@@ -1,4 +1,5 @@
 import { useState, type FormEvent } from 'react';
+import { Eye, EyeOff } from 'react-feather';
 import { Input } from 'reactstrap';
 import { buttonSize, buttonStyle } from '../../constants/constants';
 import type { Credentials } from '../../constants/types';
@@ -15,6 +16,7 @@ interface AuthFormProps {
 
 function AuthForm({ isOpen, mode, onClose }: Readonly<AuthFormProps>) {
   const [credentials, setCredentials] = useState<Credentials>({ name: '', password: '' });
+  const [isPasswordVisible, setIsPasswordVisible] = useState(false);
   const loginMutation = useLogin();
   const registerMutation = useRegister();
   const isRegister = mode === 'register';
@@ -53,16 +55,27 @@ function AuthForm({ isOpen, mode, onClose }: Readonly<AuthFormProps>) {
             <label htmlFor="auth-password" className="text-slate-800 dark:text-slate-100">
               <b>Password</b>
             </label>
-            <Input
-              id="auth-password"
-              type="password"
-              name="password"
-              placeholder="Password"
-              value={credentials.password}
-              onChange={(event) => setCredentials((prev) => ({ ...prev, password: event.target.value }))}
-              className={inputClassName}
-              required
-            />
+            <div className="relative">
+              <Input
+                id="auth-password"
+                type={isPasswordVisible ? 'text' : 'password'}
+                name="password"
+                placeholder="Password"
+                value={credentials.password}
+                onChange={(event) => setCredentials((prev) => ({ ...prev, password: event.target.value }))}
+                className={`${inputClassName} pr-10`}
+                required
+              />
+              <button
+                type="button"
+                onClick={() => setIsPasswordVisible((prev) => !prev)}
+                className="absolute inset-y-0 right-3 flex items-center text-slate-500 transition hover:text-slate-700 dark:text-slate-400 dark:hover:text-slate-200"
+                aria-label={isPasswordVisible ? 'Hide password' : 'Show password'}
+                aria-pressed={isPasswordVisible}
+              >
+                {isPasswordVisible ? <EyeOff size={18} /> : <Eye size={18} />}
+              </button>
+            </div>
           </div>
         </div>
         <div className="flex w-full justify-center">


### PR DESCRIPTION
## Description

Add an eye icon next to the password field in the form to register/login to toggle its visibility. This allow users to check their spelling before submitting theirs credentials.

<img width="1207" height="508" alt="image" src="https://github.com/user-attachments/assets/c7c412a3-3bc2-4ddd-9f2b-8ce7a127be50" />

<img width="1176" height="548" alt="image" src="https://github.com/user-attachments/assets/0a75617e-bfea-4ba6-8fe4-ff289ef740a9" />



Closes #10 