### PR TITLE
Add server health monitoring

### DIFF
--- a/backend/src/app/__init__.py
+++ b/backend/src/app/__init__.py
@@ -11,6 +11,7 @@ from pydantic import ValidationError
 from app.blueprints.articles import articles_bp
 from app.blueprints.auth import auth_bp
 from app.blueprints.authors import authors_bp
+from app.blueprints.health import health_bp
 from app.blueprints.tags import tags_bp
 from app.database import db
 from app.types import EntitiesNotFoundError
@@ -78,6 +79,7 @@ def create_app(test_config=None):
         print("handle_unexpected", str(error))
         return jsonify({"error": "Internal server error"}), 500
 
+    app.register_blueprint(health_bp)
     app.register_blueprint(auth_bp)
     app.register_blueprint(articles_bp)
     app.register_blueprint(authors_bp)

--- a/backend/src/app/blueprints/auth.py
+++ b/backend/src/app/blueprints/auth.py
@@ -63,3 +63,5 @@ def refresh(user_id):
 @jwt_required()
 def logout():
     return jsonify({"msg": "Successfully logged out"}), 200
+
+

--- a/backend/src/app/blueprints/health.py
+++ b/backend/src/app/blueprints/health.py
@@ -1,0 +1,7 @@
+from flask import Blueprint, jsonify
+
+health_bp = Blueprint("health", __name__, url_prefix="/health")
+
+@health_bp.route("", methods=["GET"])
+def health():
+    return jsonify({"msg": "Server is alive"}), 200

--- a/backend/src/tests/test_api.py
+++ b/backend/src/tests/test_api.py
@@ -2,6 +2,9 @@ import pytest
 
 from tests.conftest import INVALID_ARTICLE_CASES
 
+def test_health(client):
+    res = client.get("/health")
+    assert res.status_code == 200
 
 def test_register(client):
     res = client.post("/auth/register", json={"name": "Test", "password": "Test"})

--- a/backend/src/tests/test_api.py
+++ b/backend/src/tests/test_api.py
@@ -2,9 +2,11 @@ import pytest
 
 from tests.conftest import INVALID_ARTICLE_CASES
 
+
 def test_health(client):
     res = client.get("/health")
     assert res.status_code == 200
+
 
 def test_register(client):
     res = client.post("/auth/register", json={"name": "Test", "password": "Test"})

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -8,10 +8,12 @@ import HomePage from './components/pages/HomePage';
 import { Toaster } from 'sonner';
 import { useIsDarkMode } from './contexts/ThemeContext';
 import { useAuth } from './contexts/AuthContext';
+import { useHealth } from './hooks/queries';
 
 function App() {
   const { isConnected } = useAuth();
   const isDarkMode = useIsDarkMode();
+  useHealth();
 
   return (
     <div className="flex min-h-screen flex-col bg-gradient-to-b from-slate-50 via-slate-100 to-slate-200 text-slate-900 transition-colors dark:from-slate-900 dark:via-slate-900 dark:to-slate-800 dark:text-slate-100">

--- a/frontend/src/api/entities.ts
+++ b/frontend/src/api/entities.ts
@@ -37,6 +37,13 @@ apiClient.interceptors.response.use(
   },
 );
 
+export const healthApi = {
+  status: async (): Promise<Message> => {
+    const { data } = await axios.get(API_URLS.HEALTH);
+    return data;
+  },
+};
+
 export const authApi = {
   register: async (credentials: Credentials): Promise<Token> => {
     const { data } = await apiClient.post(API_URLS.REGISTER, credentials);

--- a/frontend/src/api/queryKeys.ts
+++ b/frontend/src/api/queryKeys.ts
@@ -16,4 +16,8 @@ export const queryKeys = {
   auth: {
     all: ['auth'],
   },
+  health: {
+    all: ['health'],
+    status: () => [...queryKeys.health.all, 'status'],
+  },
 } as const;

--- a/frontend/src/components/forms/AuthForm.tsx
+++ b/frontend/src/components/forms/AuthForm.tsx
@@ -1,10 +1,11 @@
 import { useState, type FormEvent } from 'react';
-import { Eye, EyeOff } from 'react-feather';
+import { AlertTriangle, Eye, EyeOff } from 'react-feather';
 import { Input } from 'reactstrap';
 import { buttonSize, buttonStyle } from '../../constants/constants';
 import type { Credentials } from '../../constants/types';
 import { useLogin, useRegister } from '../../hooks/mutations';
 import PopupWrapper from '../features/PopupWrapper';
+import { useHealth } from '../../hooks/queries';
 
 type AuthMode = 'login' | 'register';
 
@@ -19,12 +20,14 @@ function AuthForm({ isOpen, mode, onClose }: Readonly<AuthFormProps>) {
   const [isPasswordVisible, setIsPasswordVisible] = useState(false);
   const loginMutation = useLogin();
   const registerMutation = useRegister();
+  const { isSuccess: isServerAlive, isError: isServerUnavailable, isFetching: isCheckingServer } = useHealth();
   const isRegister = mode === 'register';
   const activeMutation = isRegister ? registerMutation : loginMutation;
   const title = isRegister ? 'Register' : 'Login';
-  const submitLabel = activeMutation.isPending ? 'Please wait...' : title;
   const inputClassName =
     'border-slate-300 bg-white text-slate-900 placeholder:text-slate-500 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-100 dark:placeholder:text-slate-400';
+  const isDisabled = activeMutation.isPending || !isServerAlive;
+  const submitLabel = !isServerAlive ? (isCheckingServer ? 'Checking server...' : 'Server unavailable') : title;
 
   function handleSubmit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
@@ -78,9 +81,18 @@ function AuthForm({ isOpen, mode, onClose }: Readonly<AuthFormProps>) {
             </div>
           </div>
         </div>
+        {isServerUnavailable && (
+          <div
+            className="flex items-start gap-2 rounded-lg border border-amber-300 bg-amber-50 px-3 py-2 text-sm text-amber-900 dark:border-amber-500/60 dark:bg-amber-950/40 dark:text-amber-100"
+            role="alert"
+          >
+            <AlertTriangle className="mt-0.5 shrink-0" size={16} />
+            <span>The server is not responding right now. Please try again in a moment.</span>
+          </div>
+        )}
         <div className="flex w-full justify-center">
-          <button className={`${buttonStyle.success} ${buttonSize.medium}`} type="submit" disabled={activeMutation.isPending}>
-            {submitLabel}
+          <button className={`${buttonStyle.success} ${buttonSize.medium}`} type="submit" disabled={isDisabled}>
+            {activeMutation.isPending ? 'Please wait...' : submitLabel}
           </button>
         </div>
       </form>

--- a/frontend/src/constants/constants.ts
+++ b/frontend/src/constants/constants.ts
@@ -9,15 +9,18 @@ export const API_URLS = {
   LOGOUT: `${baseURL}/auth/logout`,
   REGISTER: `${baseURL}/auth/register`,
   REFRESH: `${baseURL}/auth/refresh`,
+  HEALTH: `${baseURL}/health`,
 };
 
 export const buttonStyle = {
-  error: 'focus:outline-none text-white bg-red-500 hover:bg-red-700 rounded-lg',
-  warning: 'focus:outline-none text-black bg-yellow-400 hover:bg-yellow-600 rounded-lg',
+  error:
+    'focus:outline-none text-white bg-red-500 hover:bg-red-700 rounded-lg disabled:cursor-not-allowed disabled:opacity-50 disabled:hover:bg-red-500',
+  warning:
+    'focus:outline-none text-black bg-yellow-400 hover:bg-yellow-600 rounded-lg disabled:cursor-not-allowed disabled:opacity-50 disabled:hover:bg-yellow-400',
   neutral:
-    'focus:outline-none rounded-lg border border-slate-300 bg-slate-100 p-2 font-semibold tracking-wide text-slate-900 hover:bg-slate-200 hover:border-slate-400 dark:border-slate-400 dark:bg-slate-500 dark:text-white dark:hover:border-slate-300 dark:hover:bg-slate-700',
+    'focus:outline-none rounded-lg border border-slate-300 bg-slate-100 p-2 font-semibold tracking-wide text-slate-900 hover:bg-slate-200 hover:border-slate-400 disabled:cursor-not-allowed disabled:opacity-50 disabled:hover:border-slate-300 disabled:hover:bg-slate-100 dark:border-slate-400 dark:bg-slate-500 dark:text-white dark:hover:border-slate-300 dark:hover:bg-slate-700 dark:disabled:hover:border-slate-400 dark:disabled:hover:bg-slate-500',
   success:
-    'focus:outline-none rounded-lg border border-emerald-500/80 bg-emerald-100 p-2 font-semibold tracking-wide text-emerald-900 hover:border-emerald-600 hover:bg-emerald-200 dark:border-emerald-500 dark:bg-emerald-600/55 dark:text-emerald-50 dark:hover:border-emerald-400 dark:hover:bg-emerald-800/70',
+    'focus:outline-none rounded-lg border border-emerald-500/80 bg-emerald-100 p-2 font-semibold tracking-wide text-emerald-900 hover:border-emerald-600 hover:bg-emerald-200 disabled:cursor-not-allowed disabled:opacity-50 disabled:hover:border-emerald-500/80 disabled:hover:bg-emerald-100 dark:border-emerald-500 dark:bg-emerald-600/55 dark:text-emerald-50 dark:hover:border-emerald-400 dark:hover:bg-emerald-800/70 dark:disabled:hover:border-emerald-500 dark:disabled:hover:bg-emerald-600/55',
 };
 
 export const buttonSize = {

--- a/frontend/src/hooks/queries.ts
+++ b/frontend/src/hooks/queries.ts
@@ -1,5 +1,5 @@
 import { useQuery } from '@tanstack/react-query';
-import { articlesApi, authorsApi, tagsApi } from '../api/entities';
+import { articlesApi, authorsApi, tagsApi, healthApi } from '../api/entities';
 import { queryKeys } from '../api/queryKeys';
 
 export function useArticles() {
@@ -27,5 +27,14 @@ export function useAuthors() {
   return useQuery({
     queryKey: queryKeys.authors.list(),
     queryFn: authorsApi.list,
+  });
+}
+
+export function useHealth() {
+  return useQuery({
+    queryKey: queryKeys.health.status(),
+    queryFn: healthApi.status,
+    refetchInterval: 60000,
+    staleTime: 60000,
   });
 }


### PR DESCRIPTION
## Description

In production, users may experience a backend cold start. From the UI perspective, it means that the first action (login or register) is taking an unexpectedly long time without the UI provding any clear feedback. 

This PR aims to solve that by monitoring the server's health and displaying informative message to the user when the server is unreachable.

## Changes

- Added a backend /health endpoint so the frontend can detect whether the API is reachable.
- Added a basic test for this endpoint.
- Added a hook to check the server's health on the frontend - that runs on app mount and refreshes every minute.
- Disabled auth actions when the server is unavailable and added a clearer warning message in the auth form.
- Improved disabled button styling so unavailable/pending actions look visibly inactive.