### PR TITLE
Replace sessionStorage JWTs with httpOnly cookies and double-submit CSRF

### DIFF
--- a/backend/src/app/__init__.py
+++ b/backend/src/app/__init__.py
@@ -43,12 +43,12 @@ def create_app(test_config=None):
     app.config["JWT_REFRESH_TOKEN_EXPIRES"] = timedelta(days=30)
     app.config["JWT_TOKEN_LOCATION"] = ["cookies"]
     app.config["JWT_REFRESH_COOKIE_PATH"] = "/auth/refresh"
-    app.config["JWT_COOKIE_SECURE"] = True
-    app.config["JWT_COOKIE_SAMESITE"] = "None"
+    app.config["JWT_COOKIE_SECURE"] = False
+    app.config["JWT_COOKIE_SAMESITE"] = "Lax"
     app.config["JWT_COOKIE_CSRF_PROTECT"] = True
     app.config["JWT_CSRF_IN_COOKIES"] = True
 
-    _origins_raw = os.environ.get("FRONTEND_ORIGIN", "http://localhost:5173")
+    _origins_raw = os.environ.get("FRONTEND_ORIGIN", "http://localhost:3000")
     frontend_origins = [o.strip() for o in _origins_raw.split(",") if o.strip()]
     CORS(
         app,

--- a/backend/src/app/__init__.py
+++ b/backend/src/app/__init__.py
@@ -43,10 +43,14 @@ def create_app(test_config=None):
     app.config["JWT_REFRESH_TOKEN_EXPIRES"] = timedelta(days=30)
     app.config["JWT_TOKEN_LOCATION"] = ["cookies"]
     app.config["JWT_REFRESH_COOKIE_PATH"] = "/auth/refresh"
-    app.config["JWT_COOKIE_SECURE"] = False
+    app.config["JWT_COOKIE_SECURE"] = True
     app.config["JWT_COOKIE_SAMESITE"] = "Lax"
     app.config["JWT_COOKIE_CSRF_PROTECT"] = True
     app.config["JWT_CSRF_IN_COOKIES"] = True
+    app.config["JWT_COOKIE_DOMAIN"] = os.environ.get("JWT_COOKIE_DOMAIN")
+    app.config["JWT_CSRF_COOKIE_HTTPONLY"] = False
+    app.config["JWT_ACCESS_CSRF_COOKIE_PATH"] = "/"
+    app.config["JWT_REFRESH_CSRF_COOKIE_PATH"] = "/"
 
     _origins_raw = os.environ.get("FRONTEND_ORIGIN", "http://localhost:3000")
     frontend_origins = [o.strip() for o in _origins_raw.split(",") if o.strip()]

--- a/backend/src/app/__init__.py
+++ b/backend/src/app/__init__.py
@@ -41,6 +41,12 @@ def create_app(test_config=None):
     app.config["JWT_SECRET_KEY"] = os.environ["JWT_SECRET_KEY"]
     app.config["JWT_ACCESS_TOKEN_EXPIRES"] = timedelta(minutes=15)
     app.config["JWT_REFRESH_TOKEN_EXPIRES"] = timedelta(days=30)
+    app.config["JWT_TOKEN_LOCATION"] = ["cookies"]
+    app.config["JWT_REFRESH_COOKIE_PATH"] = "/auth/refresh"
+    app.config["JWT_COOKIE_SECURE"] = True
+    app.config["JWT_COOKIE_SAMESITE"] = "None"
+    app.config["JWT_COOKIE_CSRF_PROTECT"] = True
+    app.config["JWT_CSRF_IN_COOKIES"] = True
 
     _origins_raw = os.environ.get("FRONTEND_ORIGIN", "http://localhost:5173")
     frontend_origins = [o.strip() for o in _origins_raw.split(",") if o.strip()]

--- a/backend/src/app/blueprints/auth.py
+++ b/backend/src/app/blueprints/auth.py
@@ -71,7 +71,9 @@ def login(data):
 @get_user_id
 def refresh(user_id):
     access_token = create_access_token(identity=str(user_id))
-    return jsonify(access_token=access_token)
+    response = jsonify({"msg": "Refresh successful"})
+    set_access_cookies(response, access_token)
+    return jsonify(response)
 
 
 @auth_bp.route("/logout", methods=["POST"])

--- a/backend/src/app/blueprints/auth.py
+++ b/backend/src/app/blueprints/auth.py
@@ -1,5 +1,12 @@
 from flask import Blueprint, jsonify
-from flask_jwt_extended import create_access_token, create_refresh_token, jwt_required
+from flask_jwt_extended import (
+    create_access_token,
+    create_refresh_token,
+    jwt_required,
+    set_access_cookies,
+    set_refresh_cookies,
+    unset_jwt_cookies,
+)
 from sqlalchemy import select
 from werkzeug.security import check_password_hash, generate_password_hash
 
@@ -30,7 +37,11 @@ def register(data):
 
     access_token = create_access_token(identity=str(user.id))
     refresh_token = create_refresh_token(identity=str(user.id))
-    return jsonify(access_token=access_token, refresh_token=refresh_token), 201
+
+    response = jsonify({"msg": "Successfully logged-in"})
+    set_access_cookies(response, access_token)
+    set_refresh_cookies(response, refresh_token)
+    return response, 201
 
 
 @auth_bp.route("/login", methods=["POST"])
@@ -48,11 +59,15 @@ def login(data):
 
     access_token = create_access_token(identity=str(user.id))
     refresh_token = create_refresh_token(identity=str(user.id))
-    return jsonify(access_token=access_token, refresh_token=refresh_token), 200
+
+    response = jsonify({"msg": "Successfully logged-in"})
+    set_access_cookies(response, access_token)
+    set_refresh_cookies(response, refresh_token)
+    return response, 200
 
 
 @auth_bp.route("/refresh", methods=["POST"])
-@jwt_required(refresh=True)
+@jwt_required(refresh=True, locations=["cookies"])
 @get_user_id
 def refresh(user_id):
     access_token = create_access_token(identity=str(user_id))
@@ -62,6 +77,6 @@ def refresh(user_id):
 @auth_bp.route("/logout", methods=["POST"])
 @jwt_required()
 def logout():
-    return jsonify({"msg": "Successfully logged out"}), 200
-
-
+    response = jsonify({"msg": "Successfully logged-out"})
+    unset_jwt_cookies(response)
+    return response, 200

--- a/backend/src/app/blueprints/auth.py
+++ b/backend/src/app/blueprints/auth.py
@@ -67,13 +67,13 @@ def login(data):
 
 
 @auth_bp.route("/refresh", methods=["POST"])
-@jwt_required(refresh=True, locations=["cookies"])
+@jwt_required(refresh=True)
 @get_user_id
 def refresh(user_id):
     access_token = create_access_token(identity=str(user_id))
     response = jsonify({"msg": "Refresh successful"})
     set_access_cookies(response, access_token)
-    return jsonify(response)
+    return response, 200
 
 
 @auth_bp.route("/logout", methods=["POST"])

--- a/backend/src/tests/conftest.py
+++ b/backend/src/tests/conftest.py
@@ -1,7 +1,38 @@
 import pytest
+from werkzeug import Response
 
 from app import create_app
 from app.database import db as _db
+
+
+def parse_cookies(cookies: list[str], name: str) -> str | None:
+    for cookie in cookies:
+        first_pair = cookie.split(";", 1)[0].strip()
+        if not first_pair or "=" not in first_pair:
+            continue
+        cookie_name, cookie_value = first_pair.split("=", 1)
+        if cookie_name.strip() == name:
+            return cookie_value
+    return None
+
+
+def get_cookie_value(response: Response, name: str):
+    cookies = response.headers.getlist("Set-Cookie")
+    print(cookies)
+    return parse_cookies(cookies, name)
+
+
+def get_csrf_header(res: Response, csrf_type: str):
+    if csrf_type == "access":
+        csrf_access_token = get_cookie_value(res, "csrf_access_token")
+        return {
+            "X-CSRF-TOKEN": csrf_access_token,
+        }
+    else:
+        csrf_refresh_token = get_cookie_value(res, "csrf_refresh_token")
+        return {
+            "X-CSRF-TOKEN": csrf_refresh_token,
+        }
 
 
 @pytest.fixture()
@@ -24,12 +55,10 @@ def client(app):
 
 
 @pytest.fixture()
-def auth_headers(client):
+def auth_headers(client) -> dict[str, str]:
     res = client.post("/auth/register", json={"name": "Test", "password": "Test"})
     assert res.status_code == 201
-    payload = res.get_json()
-    token = payload["access_token"]
-    return {"Authorization": f"Bearer {token}"}
+    return get_csrf_header(res, "access")
 
 
 @pytest.fixture()

--- a/backend/src/tests/test_api.py
+++ b/backend/src/tests/test_api.py
@@ -1,6 +1,6 @@
 import pytest
 
-from tests.conftest import INVALID_ARTICLE_CASES
+from tests.conftest import INVALID_ARTICLE_CASES, get_cookie_value, get_csrf_header
 
 
 def test_health(client):
@@ -11,34 +11,36 @@ def test_health(client):
 def test_register(client):
     res = client.post("/auth/register", json={"name": "Test", "password": "Test"})
     assert res.status_code == 201
-    payload = res.get_json()
-    assert "access_token" in payload
-    assert "refresh_token" in payload
+    assert get_cookie_value(res, "access_token_cookie")
+    assert get_cookie_value(res, "refresh_token_cookie")
+    assert get_cookie_value(res, "csrf_access_token")
+    assert get_cookie_value(res, "csrf_refresh_token")
 
 
 def test_login(client):
     client.post("/auth/register", json={"name": "Test", "password": "Test"})
-    res2 = client.post("/auth/login", json={"name": "Test", "password": "Test"})
-    assert res2.status_code == 200
-    payload2 = res2.get_json()
-    assert "access_token" in payload2
-    assert "refresh_token" in payload2
+    res = client.post("/auth/login", json={"name": "Test", "password": "Test"})
+    assert res.status_code == 200
+    assert get_cookie_value(res, "access_token_cookie")
+    assert get_cookie_value(res, "refresh_token_cookie")
+    assert get_cookie_value(res, "csrf_access_token")
+    assert get_cookie_value(res, "csrf_refresh_token")
 
 
 def test_refresh(client):
     res = client.post("/auth/register", json={"name": "Test", "password": "Test"})
-    payload = res.get_json()
-    token = payload["refresh_token"]
-    res2 = client.post("/auth/refresh", headers={"Authorization": f"Bearer {token}"})
-    payload2 = res2.get_json()
-    assert "access_token" in payload2
+    headers = get_csrf_header(res, "refresh")
+    res = client.post("/auth/refresh", headers=headers)
+    assert res.status_code == 200
+    assert get_cookie_value(res, "access_token_cookie")
+    assert get_cookie_value(res, "csrf_access_token")
 
 
 def test_logout(auth_client):
     res = auth_client.post("/auth/logout")
     assert res.status_code == 200
-    payload = res.get_json()
-    assert payload["msg"] == "Successfully logged out"
+    assert not get_cookie_value(res, "access_token_cookie")
+    assert not get_cookie_value(res, "csrf_access_token")
 
 
 def test_method_not_allowed(client):
@@ -146,8 +148,8 @@ def test_per_user_isolation(client, mock_article):
     # User A
     res1 = client.post("/auth/register", json={"name": "Test", "password": "Test"})
     assert res1.status_code == 201
-    token1 = res1.get_json()["access_token"]
-    headers1 = {"Authorization": f"Bearer {token1}"}
+    headers1 = get_csrf_header(res1, "access")
+
     post1 = client.post("/articles", json=mock_article, headers=headers1)
     assert post1.status_code == 201
     payload1 = client.get("/articles", headers=headers1).get_json()
@@ -157,8 +159,7 @@ def test_per_user_isolation(client, mock_article):
     # User B
     res2 = client.post("/auth/register", json={"name": "Test 2", "password": "Test 2"})
     assert res2.status_code == 201
-    token2 = res2.get_json()["access_token"]
-    headers2 = {"Authorization": f"Bearer {token2}"}
+    headers2 = get_csrf_header(res2, "access")
 
     # User B cannot see User A articles
     assert len(client.get("/articles", headers=headers2).get_json()) == 0
@@ -174,4 +175,7 @@ def test_per_user_isolation(client, mock_article):
     )
 
     # A still has article
-    assert len(client.get("/articles", headers=headers1).get_json()) == 1
+    res3 = client.post("/auth/login", json={"name": "Test", "password": "Test"})
+    assert res3.status_code == 200
+    headers3 = get_csrf_header(res3, "access")
+    assert len(client.get("/articles", headers=headers3).get_json()) == 1

--- a/frontend/src/api/entities.ts
+++ b/frontend/src/api/entities.ts
@@ -1,10 +1,8 @@
 import axios from 'axios';
 import { API_URLS } from '../constants/constants';
-import type { Article, AuthorStat, Credentials, Entity, Token, AccessToken, Message } from '../constants/types';
+import type { Article, AuthorStat, Credentials, Message } from '../constants/types';
 import {
   MessageSchema,
-  TokenSchema,
-  RefreshTokenSchema,
   DeletedArticlesSchema,
   DeletedEntitiesSchema,
   EntitySchema,
@@ -13,18 +11,16 @@ import {
   ArticleSchema,
   ArticlesSchema,
 } from '../constants/schema';
+import { getCookie, normalizeEntityNames } from '../helpers/helpers';
 
 const apiClient = axios.create();
 
-function normalizeEntityNames(entities: Array<string | Entity>): string[] {
-  return entities.map((entity) => (typeof entity === 'string' ? entity : entity.name));
-}
+apiClient.defaults.withCredentials = true;
 
 apiClient.interceptors.request.use((config) => {
-  const token = sessionStorage.getItem('access_token');
-
-  if (token) {
-    config.headers.Authorization = `Bearer ${token}`;
+  const csrf_access_token = getCookie('csrf_access_token');
+  if (csrf_access_token) {
+    config.headers['X-CSRF-TOKEN'] = csrf_access_token;
   }
 
   return config;
@@ -34,17 +30,11 @@ apiClient.interceptors.response.use(
   (response) => response,
   async (error) => {
     const originalRequest = error.config;
-
     if (error.response?.status !== 401 || originalRequest._retry) {
       return Promise.reject(error);
     }
-
     originalRequest._retry = true;
-
-    const { access_token } = await authApi.refresh();
-
-    sessionStorage.setItem('access_token', access_token);
-    originalRequest.headers.Authorization = `Bearer ${access_token}`;
+    await authApi.refresh();
     return apiClient(originalRequest);
   },
 );
@@ -58,35 +48,36 @@ export const healthApi = {
 };
 
 export const authApi = {
-  register: async (credentials: Credentials): Promise<Token> => {
+  register: async (credentials: Credentials): Promise<Message> => {
     const { data } = await apiClient.post(API_URLS.REGISTER, credentials);
-    const result = TokenSchema.parse(data);
+    const result = MessageSchema.parse(data);
     return result;
   },
-  login: async (credentials: Credentials): Promise<Token> => {
+  login: async (credentials: Credentials): Promise<Message> => {
     const { data } = await apiClient.post(API_URLS.LOGIN, credentials);
-    const result = TokenSchema.parse(data);
+    const result = MessageSchema.parse(data);
     return result;
   },
-  refresh: async (): Promise<AccessToken> => {
-    const refreshToken = sessionStorage.getItem('refresh_token');
+  refresh: async (): Promise<Message> => {
+    const csrf_refresh_token = getCookie('csrf_refresh_token');
 
-    if (!refreshToken) {
-      throw new Error('Missing refresh token');
+    if (!csrf_refresh_token) {
+      throw new Error('Missing refresh CSRF cookie');
     }
 
-    const { data } = await axios.post(
+    const axiosClient = axios.create();
+    axiosClient.defaults.withCredentials = true;
+    const { data } = await axiosClient.post(
       API_URLS.REFRESH,
       {},
       {
         headers: {
-          Authorization: `Bearer ${refreshToken}`,
+          'X-CSRF-TOKEN': csrf_refresh_token,
         },
       },
     );
-
-    const response = RefreshTokenSchema.parse(data);
-    return response;
+    const result = MessageSchema.parse(data);
+    return result;
   },
   logout: async (): Promise<Message> => {
     const { data } = await apiClient.post(API_URLS.LOGOUT);

--- a/frontend/src/api/entities.ts
+++ b/frontend/src/api/entities.ts
@@ -30,7 +30,8 @@ apiClient.interceptors.response.use(
   (response) => response,
   async (error) => {
     const originalRequest = error.config;
-    if (error.response?.status !== 401 || originalRequest._retry) {
+    const authUrls = [API_URLS.LOGIN, API_URLS.REGISTER, API_URLS.REFRESH];
+    if (error.response?.status !== 401 || originalRequest._retry || authUrls.includes(originalRequest.url)) {
       return Promise.reject(error);
     }
     originalRequest._retry = true;

--- a/frontend/src/constants/constants.ts
+++ b/frontend/src/constants/constants.ts
@@ -1,4 +1,4 @@
-const baseURL: string = import.meta.env.VITE_API_BASE_URL ?? 'http://127.0.0.1:5000';
+const baseURL: string = import.meta.env.VITE_API_BASE_URL ?? 'http://localhost:5000';
 
 export const API_URLS = {
   ARTICLES: `${baseURL}/articles`,

--- a/frontend/src/constants/schema.ts
+++ b/frontend/src/constants/schema.ts
@@ -3,16 +3,6 @@ import * as z from 'zod';
 export const MessageSchema = z.object({
   msg: z.string(),
 });
-
-export const TokenSchema = z.object({
-  access_token: z.string(),
-  refresh_token: z.string(),
-});
-
-export const RefreshTokenSchema = z.object({
-  access_token: z.string(),
-});
-
 export const EntitySchema = z.object({
   id: z.int(),
   name: z.string(),

--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -11,7 +11,7 @@ const AuthContext = createContext<Auth | undefined>(undefined);
 
 export function AuthProvider({ children }: { children: React.ReactNode }) {
   const qc = useQueryClient();
-  const [isConnected, setIsConnected] = useState<boolean>(!!sessionStorage.getItem('access_token'));
+  const [isConnected, setIsConnected] = useState<boolean>(false);
 
   const login = () => {
     setIsConnected(true);

--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -3,7 +3,7 @@ import { useQueryClient } from '@tanstack/react-query';
 
 interface Auth {
   isConnected: boolean;
-  login: (access_token: string, refresh_token: string) => void;
+  login: () => void;
   logout: () => void;
 }
 
@@ -13,15 +13,11 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   const qc = useQueryClient();
   const [isConnected, setIsConnected] = useState<boolean>(!!sessionStorage.getItem('access_token'));
 
-  const login = (access_token: string, refresh_token: string) => {
-    sessionStorage.setItem('access_token', access_token);
-    sessionStorage.setItem('refresh_token', refresh_token);
+  const login = () => {
     setIsConnected(true);
   };
 
   const logout = () => {
-    sessionStorage.removeItem('access_token');
-    sessionStorage.removeItem('refresh_token');
     setIsConnected(false);
     qc.clear();
   };

--- a/frontend/src/helpers/helpers.ts
+++ b/frontend/src/helpers/helpers.ts
@@ -1,0 +1,16 @@
+import type { Entity } from '../constants/types';
+
+export function getCookie(name: string): string | undefined {
+  const nameEQ = name + '=';
+  const ca = document.cookie.split(';');
+  for (let i = 0; i < ca.length; i++) {
+    let c = ca[i];
+    while (c.charAt(0) == ' ') c = c.substring(1, c.length);
+    if (c.indexOf(nameEQ) == 0) return c.substring(nameEQ.length, c.length);
+  }
+  return undefined;
+}
+
+export function normalizeEntityNames(entities: Array<string | Entity>): string[] {
+  return entities.map((entity) => (typeof entity === 'string' ? entity : entity.name));
+}

--- a/frontend/src/hooks/mutations.ts
+++ b/frontend/src/hooks/mutations.ts
@@ -3,7 +3,7 @@ import axios from 'axios';
 import { toast } from 'sonner';
 import { articlesApi, authorsApi, tagsApi, authApi } from '../api/entities';
 import { queryKeys } from '../api/queryKeys';
-import { Token } from '../constants/types';
+import { Message } from '../constants/types';
 import { useAuth } from '../contexts/AuthContext';
 
 function extractErrorMessage(err: unknown): string {
@@ -37,13 +37,11 @@ export const useRemoveArticle = () => useEntitiesMutation(articlesApi.remove, qu
 export const useCreateAuthor = () => useEntitiesMutation(authorsApi.create, queryKeys.authors.all, 'Author successfully added');
 export const useCreateTag = () => useEntitiesMutation(tagsApi.create, queryKeys.tags.all, 'Tag successfully added');
 
-function useAuthMutation<TArgs>(mutationFn: (args: TArgs) => Promise<Token>) {
+function useAuthMutation<TArgs>(mutationFn: (args: TArgs) => Promise<Message>) {
   const { login } = useAuth();
   return useMutation({
     mutationFn,
-    onSuccess: (res) => {
-      login(res.access_token, res.refresh_token);
-    },
+    onSuccess: () => login(),
     onError: (err) => {
       toast.error(extractErrorMessage(err));
     },
@@ -63,6 +61,7 @@ export const useLogout = () => {
     },
     onError: () => {
       logout();
+      qc.clear();
     },
   });
 };

--- a/frontend/src/hooks/mutations.ts
+++ b/frontend/src/hooks/mutations.ts
@@ -61,7 +61,6 @@ export const useLogout = () => {
     },
     onError: () => {
       logout();
-      qc.clear();
     },
   });
 };


### PR DESCRIPTION
## Description
Moves authentication from JWTs in sessionStorage to HTTP-only, Secure, SameSite cookies issued by the backend. 

## Problem
The application stored JWT tokens on the frontend using sessionStorage which exposed them to XSS attacks. This PR solves it by storing the tokens in httpOnly cookies instead. To protect the frontend against CSRF attacks, the backend also implements a double submit pattern and the frontend manually includes the CSRF tokens in the requests.

## Changes
- Stored access and refresh tokens in httpOnly cookies
- Activated CSRF tokens on the backend
- Protected state-changing API calls with CSRF
- Register/login no longer return access/refresh tokens in the JSON body
- Adapted frontend to use credentialed requests and set the CSRF token in the X-CSRF-TOKEN header
- Configured CORS for credentialed cross-origin requests (supports_credentials + explicit FRONTEND_ORIGIN)
- Adapted backend tests to cookies
