### PR TITLE
feat(backend): add structured logging throughout API

### DIFF
--- a/backend/src/app/__init__.py
+++ b/backend/src/app/__init__.py
@@ -1,9 +1,11 @@
+import logging
 import os
+import time
 from datetime import timedelta
 from pathlib import Path
 
 from dotenv import load_dotenv
-from flask import Flask, jsonify
+from flask import Flask, jsonify, request
 from flask_cors import CORS
 from flask_jwt_extended import JWTManager
 from pydantic import ValidationError
@@ -20,6 +22,14 @@ from app.types import EntitiesNotFoundError
 BASE_DIR = Path(__file__).resolve().parents[2]
 load_dotenv(BASE_DIR / ".env")
 
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+    datefmt="%Y-%m-%d %H:%M:%S",
+)
+
+logger = logging.getLogger("article_manager")
+
 
 def _normalize_database_url(url: str) -> str:
     """Render and others often use postgres:// or postgresql://; SQLAlchemy needs the psycopg3 driver prefix."""
@@ -34,11 +44,26 @@ def _normalize_database_url(url: str) -> str:
 
 def create_app(test_config=None):
     app = Flask(__name__)
-    app.config["SQLALCHEMY_DATABASE_URI"] = _normalize_database_url(
-        os.environ["DATABASE_URL"]
-    )
-    app.config["SECRET_KEY"] = os.environ["SECRET_KEY"]
-    app.config["JWT_SECRET_KEY"] = os.environ["JWT_SECRET_KEY"]
+
+    if test_config is not None:
+        app.config.update(test_config)
+    else:
+        app.config["SQLALCHEMY_DATABASE_URI"] = _normalize_database_url(
+            os.environ["DATABASE_URL"]
+        )
+        app.config["SECRET_KEY"] = os.environ["SECRET_KEY"]
+        app.config["JWT_SECRET_KEY"] = os.environ["JWT_SECRET_KEY"]
+
+        _origins_raw = os.environ.get("FRONTEND_ORIGIN", "http://localhost:3000")
+        frontend_origins = [o.strip() for o in _origins_raw.split(",") if o.strip()]
+        CORS(
+            app,
+            resources={r"/*": {"origins": frontend_origins}},
+            supports_credentials=True,
+        )
+        
+    app.config.setdefault("SECRET_KEY", os.environ.get("SECRET_KEY", ""))
+    app.config.setdefault("JWT_SECRET_KEY", os.environ.get("JWT_SECRET_KEY", ""))
     app.config["JWT_ACCESS_TOKEN_EXPIRES"] = timedelta(minutes=15)
     app.config["JWT_REFRESH_TOKEN_EXPIRES"] = timedelta(days=30)
     app.config["JWT_TOKEN_LOCATION"] = ["cookies"]
@@ -52,22 +77,28 @@ def create_app(test_config=None):
     app.config["JWT_ACCESS_CSRF_COOKIE_PATH"] = "/"
     app.config["JWT_REFRESH_CSRF_COOKIE_PATH"] = "/"
 
-    _origins_raw = os.environ.get("FRONTEND_ORIGIN", "http://localhost:3000")
-    frontend_origins = [o.strip() for o in _origins_raw.split(",") if o.strip()]
-    CORS(
-        app,
-        resources={r"/*": {"origins": frontend_origins}},
-        supports_credentials=True,
-    )
-
-    if test_config is not None:
-        app.config.update(test_config)
-
     db.init_app(app)
     JWTManager(app)
 
     with app.app_context():
         db.create_all()
+
+    @app.before_request
+    def _log_request_start():
+        request.start_time = time.perf_counter()
+        logger.info("→ %s %s", request.method, request.path)
+
+    @app.after_request
+    def _log_request_end(response):
+        duration_ms = (time.perf_counter() - request.start_time) * 1000
+        logger.info(
+            "← %s %s %d (%.1fms)",
+            request.method,
+            request.path,
+            response.status_code,
+            duration_ms,
+        )
+        return response
 
     @app.route("/favicon.ico")
     def favicon():
@@ -75,14 +106,17 @@ def create_app(test_config=None):
 
     @app.errorhandler(ValidationError)
     def handle_validation_error(error):
+        logger.warning("Validation error on %s %s: %s", request.method, request.path, error.errors())
         return jsonify({"error": error.errors()}), 422
 
     @app.errorhandler(EntitiesNotFoundError)
     def handle_entities_not_found_error(error):
+        logger.warning("Entities not found on %s %s: missing_ids=%s", request.method, request.path, error.missing_ids)
         return jsonify({"error": str(error), "missing_ids": error.missing_ids}), 404
 
     @app.errorhandler(HTTPException)
     def handle_http_exception(error):
+        logger.warning("HTTP %d on %s %s: %s", error.code, request.method, request.path, error.description)
         return jsonify({"error": error.description}), error.code
 
     app.register_blueprint(health_bp)
@@ -91,4 +125,5 @@ def create_app(test_config=None):
     app.register_blueprint(authors_bp)
     app.register_blueprint(tags_bp)
 
+    logger.info("App created — blueprints registered, DB ready")
     return app

--- a/backend/src/app/blueprints/articles.py
+++ b/backend/src/app/blueprints/articles.py
@@ -1,3 +1,5 @@
+import logging
+
 from flask import Blueprint, jsonify
 from flask_jwt_extended import jwt_required
 from sqlalchemy import select
@@ -15,6 +17,8 @@ from app.services import (
     update_model_fields,
 )
 
+logger = logging.getLogger("article_manager.articles")
+
 articles_bp = Blueprint("articles", __name__, url_prefix="/articles")
 
 
@@ -24,6 +28,7 @@ articles_bp = Blueprint("articles", __name__, url_prefix="/articles")
 def list_articles(user_id):
     stmt = select(Article).where(Article.user_id == user_id)
     articles = db.session.execute(stmt).scalars().all()
+    logger.debug("Listed %d articles for user_id=%d", len(articles), user_id)
     return jsonify([article.to_dict() for article in articles]), 200
 
 
@@ -34,6 +39,7 @@ def list_articles(user_id):
 def add_article(data, user_id):
     schema = ArticleSchema.model_validate(data)
     if not check_url_uniqueness(schema.url, user_id):
+        logger.warning("Add article failed — duplicate URL for user_id=%d: %s", user_id, schema.url)
         return jsonify({"error": "URL already exists"}), 409
 
     tags = associate_tags(schema.tags, user_id)
@@ -53,6 +59,7 @@ def add_article(data, user_id):
     )
     db.session.add(article)
     db.session.commit()
+    logger.info("Article created: id=%d title=%r user_id=%d", article.id, article.title, user_id)
     return jsonify(article.to_dict()), 201
 
 
@@ -63,8 +70,10 @@ def add_article(data, user_id):
 def edit_article(data, user_id):
     schema = ArticleSchema.model_validate(data)
     if schema.id is None:
+        logger.warning("Edit article failed — missing id for user_id=%d", user_id)
         return jsonify({"error": "Missing id"}), 400
     if not check_url_uniqueness(schema.url, user_id, schema.id):
+        logger.warning("Edit article failed — duplicate URL for user_id=%d article_id=%d: %s", user_id, schema.id, schema.url)
         return jsonify({"error": "URL already exists"}), 409
     article = get_entity(schema.id, Article, user_id)
     tags = associate_tags(schema.tags, user_id)
@@ -88,6 +97,7 @@ def edit_article(data, user_id):
         },
     )
     db.session.commit()
+    logger.info("Article updated: id=%d title=%r user_id=%d", article.id, article.title, user_id)
     return (jsonify(article.to_dict()), 200)
 
 
@@ -103,6 +113,7 @@ def delete_articles(data, user_id):
     for article in articles:
         db.session.delete(article)
     db.session.commit()
+    logger.info("Articles deleted: ids=%s user_id=%d count=%d", schema.ids, user_id, len(articles))
     return (
         jsonify(
             {

--- a/backend/src/app/blueprints/auth.py
+++ b/backend/src/app/blueprints/auth.py
@@ -1,3 +1,5 @@
+import logging
+
 from flask import Blueprint, jsonify
 from flask_jwt_extended import (
     create_access_token,
@@ -15,6 +17,8 @@ from app.decorators import get_user_id, validate_json
 from app.models import User
 from app.schemas import UserSchema
 
+logger = logging.getLogger("article_manager.auth")
+
 auth_bp = Blueprint("auth", __name__, url_prefix="/auth")
 
 
@@ -29,11 +33,13 @@ def register(data):
     stmt = select(User).where(User.name == username)
     user = db.session.execute(stmt).scalars().first()
     if user is not None:
+        logger.warning("Register failed — username already taken: %r", username)
         return jsonify({"error": "Username unavailable"}), 409
 
     user = User(name=username, password_hash=password_hash)
     db.session.add(user)
     db.session.commit()
+    logger.info("User registered: id=%d name=%r", user.id, username)
 
     access_token = create_access_token(identity=str(user.id))
     refresh_token = create_refresh_token(identity=str(user.id))
@@ -55,8 +61,10 @@ def login(data):
     user = db.session.execute(stmt).scalars().first()
 
     if user is None or not check_password_hash(user.password_hash, password):
+        logger.warning("Login failed — wrong credentials for username: %r", username)
         return jsonify({"error": "Wrong username or password"}), 401
 
+    logger.info("User logged in: id=%d name=%r", user.id, username)
     access_token = create_access_token(identity=str(user.id))
     refresh_token = create_refresh_token(identity=str(user.id))
 
@@ -70,6 +78,7 @@ def login(data):
 @jwt_required(refresh=True)
 @get_user_id
 def refresh(user_id):
+    logger.info("Token refreshed: user_id=%d", user_id)
     access_token = create_access_token(identity=str(user_id))
     response = jsonify({"msg": "Refresh successful"})
     set_access_cookies(response, access_token)
@@ -79,6 +88,7 @@ def refresh(user_id):
 @auth_bp.route("/logout", methods=["POST"])
 @jwt_required()
 def logout():
+    logger.info("User logged out")
     response = jsonify({"msg": "Successfully logged-out"})
     unset_jwt_cookies(response)
     return response, 200

--- a/backend/src/app/blueprints/authors.py
+++ b/backend/src/app/blueprints/authors.py
@@ -1,3 +1,5 @@
+import logging
+
 from flask import Blueprint, jsonify
 from flask_jwt_extended import jwt_required
 from sqlalchemy import func, select
@@ -8,6 +10,8 @@ from app.models import Article, Author
 from app.schemas import BasicSchema, IDSchema
 from app.services import get_articles_by_author, get_entities, get_or_create_by_name
 
+logger = logging.getLogger("article_manager.authors")
+
 authors_bp = Blueprint("authors", __name__, url_prefix="/authors")
 
 
@@ -17,6 +21,7 @@ authors_bp = Blueprint("authors", __name__, url_prefix="/authors")
 def list_authors(user_id):
     stmt = select(Author).where(Author.user_id == user_id)
     authors = db.session.execute(stmt).scalars().all()
+    logger.debug("Listed %d authors for user_id=%d", len(authors), user_id)
     return jsonify([author.to_dict() for author in authors]), 200
 
 
@@ -33,6 +38,7 @@ def list_top_authors(user_id):
         .order_by(nb_articles.desc(), Author.name.asc())
     )
     rows = db.session.execute(stmt).all()
+    logger.debug("Top authors fetched for user_id=%d: %d results", user_id, len(rows))
     return (
         jsonify(
             [
@@ -52,6 +58,7 @@ def add_author(data, user_id):
     schema = BasicSchema.model_validate(data)
     author = get_or_create_by_name(Author, schema.name, user_id)
     db.session.commit()
+    logger.info("Author created/retrieved: id=%d name=%r user_id=%d", author.id, author.name, user_id)
     return jsonify(author.to_dict()), 201
 
 
@@ -67,12 +74,14 @@ def delete_authors(data, user_id):
     for author in authors:
         articles = get_articles_by_author(author.id, user_id)
         if articles:
+            logger.warning("Delete author blocked — has articles: author_id=%d user_id=%d", author.id, user_id)
             return (
                 jsonify({"error": f"The author {author.id} has associated articles."}),
                 409,
             )
         db.session.delete(author)
     db.session.commit()
+    logger.info("Authors deleted: ids=%s user_id=%d count=%d", schema.ids, user_id, len(authors))
     return (
         jsonify(
             {

--- a/backend/src/app/blueprints/tags.py
+++ b/backend/src/app/blueprints/tags.py
@@ -1,3 +1,5 @@
+import logging
+
 from flask import Blueprint, jsonify
 from flask_jwt_extended import jwt_required
 from sqlalchemy import select
@@ -8,6 +10,8 @@ from app.models import Tag
 from app.schemas import BasicSchema, IDSchema
 from app.services import get_entities, get_or_create_by_name
 
+logger = logging.getLogger("article_manager.tags")
+
 tags_bp = Blueprint("tags", __name__, url_prefix="/tags")
 
 
@@ -17,6 +21,7 @@ tags_bp = Blueprint("tags", __name__, url_prefix="/tags")
 def list_tags(user_id):
     stmt = select(Tag).where(Tag.user_id == user_id)
     tags = db.session.execute(stmt).scalars().all()
+    logger.debug("Listed %d tags for user_id=%d", len(tags), user_id)
     return jsonify([tag.to_dict() for tag in tags]), 200
 
 
@@ -28,6 +33,7 @@ def add_tag(data, user_id):
     schema = BasicSchema.model_validate(data)
     tag = get_or_create_by_name(Tag, schema.name, user_id)
     db.session.commit()
+    logger.info("Tag created/retrieved: id=%d name=%r user_id=%d", tag.id, tag.name, user_id)
     return jsonify(tag.to_dict()), 201
 
 
@@ -41,6 +47,7 @@ def delete_tags(data, user_id):
     for tag in tags:
         db.session.delete(tag)
     db.session.commit()
+    logger.info("Tags deleted: ids=%s user_id=%d count=%d", schema.ids, user_id, len(tags))
     return (
         jsonify({"deleted": [tag.to_dict() for tag in tags], "count": len(tags)}),
         200,


### PR DESCRIPTION
Added Python's built-in `logging` module across all blueprint files to make debugging production issues easier.

**Changes made:**
- Configured logging in `__init__.py` with a consistent format and request timing via before_request/after_request hooks
- `auth.py` — logs register, login, refresh, and logout events
- `articles.py` — logs create, update, delete, and error cases
- `authors.py`— logs create, delete, and conflict cases
- `tags.py` — logs create and delete events

> **Note:** The `create_app `factory was reading `DATABASE_URL`, `SECRET_KEY`, and `JWT_SECRET_KEY` from the environment before applying `test_config`, which caused all 21 tests to fail with `KeyError` even before this PR's changes. Fixed this as part of the work to get tests passing — the fix is outside the scope of this issue but was a blocker for verifying the logging changes.

**Test results:**
<img width="1560" height="547" alt="Screenshot 2026-05-03 183455" src="https://github.com/user-attachments/assets/073a4099-4eb0-4f51-9fb3-eb4975bb93f4" />