### PR TITLE
refactor(backend): domain error for duplicate article URL + route type hints

### DIFF
--- a/backend/src/app/__init__.py
+++ b/backend/src/app/__init__.py
@@ -17,6 +17,7 @@ from app.blueprints.authors import authors_bp
 from app.blueprints.health import health_bp
 from app.blueprints.tags import tags_bp
 from app.database import db
+from app.exceptions import EntityDuplicatedError
 from app.types import EntitiesNotFoundError
 
 BASE_DIR = Path(__file__).resolve().parents[2]
@@ -61,7 +62,7 @@ def create_app(test_config=None):
             resources={r"/*": {"origins": frontend_origins}},
             supports_credentials=True,
         )
-        
+
     app.config.setdefault("SECRET_KEY", os.environ.get("SECRET_KEY", ""))
     app.config.setdefault("JWT_SECRET_KEY", os.environ.get("JWT_SECRET_KEY", ""))
     app.config["JWT_ACCESS_TOKEN_EXPIRES"] = timedelta(minutes=15)
@@ -104,19 +105,42 @@ def create_app(test_config=None):
     def favicon():
         return "", 204
 
+    @app.errorhandler(EntityDuplicatedError)
+    def handle_duplicated_error(error: EntityDuplicatedError):
+        logger.warning(
+            f"{error.action} failed — duplicate {error.entity_name} for user_id={error.user_id}: {error.entity_id}"
+        )
+        return jsonify({"error": str(error)}), 409
+
     @app.errorhandler(ValidationError)
     def handle_validation_error(error):
-        logger.warning("Validation error on %s %s: %s", request.method, request.path, error.errors())
+        logger.warning(
+            "Validation error on %s %s: %s",
+            request.method,
+            request.path,
+            error.errors(),
+        )
         return jsonify({"error": error.errors()}), 422
 
     @app.errorhandler(EntitiesNotFoundError)
     def handle_entities_not_found_error(error):
-        logger.warning("Entities not found on %s %s: missing_ids=%s", request.method, request.path, error.missing_ids)
+        logger.warning(
+            "Entities not found on %s %s: missing_ids=%s",
+            request.method,
+            request.path,
+            error.missing_ids,
+        )
         return jsonify({"error": str(error), "missing_ids": error.missing_ids}), 404
 
     @app.errorhandler(HTTPException)
     def handle_http_exception(error):
-        logger.warning("HTTP %d on %s %s: %s", error.code, request.method, request.path, error.description)
+        logger.warning(
+            "HTTP %d on %s %s: %s",
+            error.code,
+            request.method,
+            request.path,
+            error.description,
+        )
         return jsonify({"error": error.description}), error.code
 
     app.register_blueprint(health_bp)

--- a/backend/src/app/blueprints/articles.py
+++ b/backend/src/app/blueprints/articles.py
@@ -1,4 +1,5 @@
 import logging
+from typing import Any
 
 from flask import Blueprint, jsonify
 from flask_jwt_extended import jwt_required
@@ -26,7 +27,7 @@ articles_bp = Blueprint("articles", __name__, url_prefix="/articles")
 @articles_bp.route("")
 @jwt_required()
 @get_user_id
-def list_articles(user_id):
+def list_articles(user_id: int):
     stmt = select(Article).where(Article.user_id == user_id)
     articles = db.session.execute(stmt).scalars().all()
     logger.debug("Listed %d articles for user_id=%d", len(articles), user_id)
@@ -37,7 +38,7 @@ def list_articles(user_id):
 @jwt_required()
 @validate_json
 @get_user_id
-def add_article(data, user_id):
+def add_article(data: dict[str, Any], user_id: int):
     schema = ArticleSchema.model_validate(data)
     if not check_url_uniqueness(schema.url, user_id):
         raise EntityDuplicatedError("Add article", user_id, "URL", schema.url)
@@ -69,7 +70,7 @@ def add_article(data, user_id):
 @jwt_required()
 @validate_json
 @get_user_id
-def edit_article(data, user_id):
+def edit_article(data: dict[str, Any], user_id: int):
     schema = ArticleSchema.model_validate(data)
     if schema.id is None:
         logger.warning("Edit article failed — missing id for user_id=%d", user_id)
@@ -108,7 +109,7 @@ def edit_article(data, user_id):
 @jwt_required()
 @validate_json
 @get_user_id
-def delete_articles(data, user_id):
+def delete_articles(data: dict[str, Any], user_id: int):
     schema = IDSchema.model_validate(data)
     article_ids = schema.ids
     articles = get_entities(article_ids, Article, user_id)

--- a/backend/src/app/blueprints/articles.py
+++ b/backend/src/app/blueprints/articles.py
@@ -6,6 +6,7 @@ from sqlalchemy import select
 
 from app.database import db
 from app.decorators import get_user_id, validate_json
+from app.exceptions import EntityDuplicatedError
 from app.models import Article, Author
 from app.schemas import ArticleSchema, IDSchema
 from app.services import (
@@ -39,8 +40,7 @@ def list_articles(user_id):
 def add_article(data, user_id):
     schema = ArticleSchema.model_validate(data)
     if not check_url_uniqueness(schema.url, user_id):
-        logger.warning("Add article failed — duplicate URL for user_id=%d: %s", user_id, schema.url)
-        return jsonify({"error": "URL already exists"}), 409
+        raise EntityDuplicatedError("Add article", user_id, "URL", schema.url)
 
     tags = associate_tags(schema.tags, user_id)
     author = get_or_create_by_name(Author, schema.author, user_id)
@@ -59,7 +59,9 @@ def add_article(data, user_id):
     )
     db.session.add(article)
     db.session.commit()
-    logger.info("Article created: id=%d title=%r user_id=%d", article.id, article.title, user_id)
+    logger.info(
+        "Article created: id=%d title=%r user_id=%d", article.id, article.title, user_id
+    )
     return jsonify(article.to_dict()), 201
 
 
@@ -73,8 +75,7 @@ def edit_article(data, user_id):
         logger.warning("Edit article failed — missing id for user_id=%d", user_id)
         return jsonify({"error": "Missing id"}), 400
     if not check_url_uniqueness(schema.url, user_id, schema.id):
-        logger.warning("Edit article failed — duplicate URL for user_id=%d article_id=%d: %s", user_id, schema.id, schema.url)
-        return jsonify({"error": "URL already exists"}), 409
+        raise EntityDuplicatedError("Edit article", user_id, "URL", schema.url)
     article = get_entity(schema.id, Article, user_id)
     tags = associate_tags(schema.tags, user_id)
     author = get_or_create_by_name(Author, schema.author, user_id)
@@ -97,7 +98,9 @@ def edit_article(data, user_id):
         },
     )
     db.session.commit()
-    logger.info("Article updated: id=%d title=%r user_id=%d", article.id, article.title, user_id)
+    logger.info(
+        "Article updated: id=%d title=%r user_id=%d", article.id, article.title, user_id
+    )
     return (jsonify(article.to_dict()), 200)
 
 
@@ -113,7 +116,12 @@ def delete_articles(data, user_id):
     for article in articles:
         db.session.delete(article)
     db.session.commit()
-    logger.info("Articles deleted: ids=%s user_id=%d count=%d", schema.ids, user_id, len(articles))
+    logger.info(
+        "Articles deleted: ids=%s user_id=%d count=%d",
+        schema.ids,
+        user_id,
+        len(articles),
+    )
     return (
         jsonify(
             {

--- a/backend/src/app/blueprints/auth.py
+++ b/backend/src/app/blueprints/auth.py
@@ -1,4 +1,5 @@
 import logging
+from typing import Any
 
 from flask import Blueprint, jsonify
 from flask_jwt_extended import (
@@ -24,7 +25,7 @@ auth_bp = Blueprint("auth", __name__, url_prefix="/auth")
 
 @auth_bp.route("/register", methods=["POST"])
 @validate_json
-def register(data):
+def register(data: dict[str, Any]):
     schema = UserSchema.model_validate(data)
     username = schema.name
     password = schema.password
@@ -52,7 +53,7 @@ def register(data):
 
 @auth_bp.route("/login", methods=["POST"])
 @validate_json
-def login(data):
+def login(data: dict[str, Any]):
     schema = UserSchema.model_validate(data)
     username = schema.name
     password = schema.password
@@ -77,7 +78,7 @@ def login(data):
 @auth_bp.route("/refresh", methods=["POST"])
 @jwt_required(refresh=True)
 @get_user_id
-def refresh(user_id):
+def refresh(user_id: int):
     logger.info("Token refreshed: user_id=%d", user_id)
     access_token = create_access_token(identity=str(user_id))
     response = jsonify({"msg": "Refresh successful"})

--- a/backend/src/app/blueprints/authors.py
+++ b/backend/src/app/blueprints/authors.py
@@ -1,4 +1,5 @@
 import logging
+from typing import Any
 
 from flask import Blueprint, jsonify
 from flask_jwt_extended import jwt_required
@@ -18,7 +19,7 @@ authors_bp = Blueprint("authors", __name__, url_prefix="/authors")
 @authors_bp.route("")
 @jwt_required()
 @get_user_id
-def list_authors(user_id):
+def list_authors(user_id: int):
     stmt = select(Author).where(Author.user_id == user_id)
     authors = db.session.execute(stmt).scalars().all()
     logger.debug("Listed %d authors for user_id=%d", len(authors), user_id)
@@ -28,7 +29,7 @@ def list_authors(user_id):
 @authors_bp.route("/top")
 @jwt_required()
 @get_user_id
-def list_top_authors(user_id):
+def list_top_authors(user_id: int):
     nb_articles = func.count(Article.id).label("nb_articles")
     stmt = (
         select(Author, nb_articles)
@@ -54,11 +55,16 @@ def list_top_authors(user_id):
 @jwt_required()
 @validate_json
 @get_user_id
-def add_author(data, user_id):
+def add_author(data: dict[str, Any], user_id: int):
     schema = BasicSchema.model_validate(data)
     author = get_or_create_by_name(Author, schema.name, user_id)
     db.session.commit()
-    logger.info("Author created/retrieved: id=%d name=%r user_id=%d", author.id, author.name, user_id)
+    logger.info(
+        "Author created/retrieved: id=%d name=%r user_id=%d",
+        author.id,
+        author.name,
+        user_id,
+    )
     return jsonify(author.to_dict()), 201
 
 
@@ -66,7 +72,7 @@ def add_author(data, user_id):
 @jwt_required()
 @validate_json
 @get_user_id
-def delete_authors(data, user_id):
+def delete_authors(data: dict[str, Any], user_id: int):
     schema = IDSchema.model_validate(data)
     author_ids = schema.ids
     authors = get_entities(author_ids, Author, user_id)
@@ -74,14 +80,20 @@ def delete_authors(data, user_id):
     for author in authors:
         articles = get_articles_by_author(author.id, user_id)
         if articles:
-            logger.warning("Delete author blocked — has articles: author_id=%d user_id=%d", author.id, user_id)
+            logger.warning(
+                "Delete author blocked — has articles: author_id=%d user_id=%d",
+                author.id,
+                user_id,
+            )
             return (
                 jsonify({"error": f"The author {author.id} has associated articles."}),
                 409,
             )
         db.session.delete(author)
     db.session.commit()
-    logger.info("Authors deleted: ids=%s user_id=%d count=%d", schema.ids, user_id, len(authors))
+    logger.info(
+        "Authors deleted: ids=%s user_id=%d count=%d", schema.ids, user_id, len(authors)
+    )
     return (
         jsonify(
             {

--- a/backend/src/app/blueprints/tags.py
+++ b/backend/src/app/blueprints/tags.py
@@ -1,4 +1,5 @@
 import logging
+from typing import Any
 
 from flask import Blueprint, jsonify
 from flask_jwt_extended import jwt_required
@@ -18,7 +19,7 @@ tags_bp = Blueprint("tags", __name__, url_prefix="/tags")
 @tags_bp.route("")
 @jwt_required()
 @get_user_id
-def list_tags(user_id):
+def list_tags(user_id: int):
     stmt = select(Tag).where(Tag.user_id == user_id)
     tags = db.session.execute(stmt).scalars().all()
     logger.debug("Listed %d tags for user_id=%d", len(tags), user_id)
@@ -29,11 +30,13 @@ def list_tags(user_id):
 @jwt_required()
 @validate_json
 @get_user_id
-def add_tag(data, user_id):
+def add_tag(data: dict[str, Any], user_id: int):
     schema = BasicSchema.model_validate(data)
     tag = get_or_create_by_name(Tag, schema.name, user_id)
     db.session.commit()
-    logger.info("Tag created/retrieved: id=%d name=%r user_id=%d", tag.id, tag.name, user_id)
+    logger.info(
+        "Tag created/retrieved: id=%d name=%r user_id=%d", tag.id, tag.name, user_id
+    )
     return jsonify(tag.to_dict()), 201
 
 
@@ -41,13 +44,15 @@ def add_tag(data, user_id):
 @jwt_required()
 @validate_json
 @get_user_id
-def delete_tags(data, user_id):
+def delete_tags(data: dict[str, Any], user_id: int):
     schema = IDSchema.model_validate(data)
     tags = get_entities(schema.ids, Tag, user_id)
     for tag in tags:
         db.session.delete(tag)
     db.session.commit()
-    logger.info("Tags deleted: ids=%s user_id=%d count=%d", schema.ids, user_id, len(tags))
+    logger.info(
+        "Tags deleted: ids=%s user_id=%d count=%d", schema.ids, user_id, len(tags)
+    )
     return (
         jsonify({"deleted": [tag.to_dict() for tag in tags], "count": len(tags)}),
         200,

--- a/backend/src/app/exceptions.py
+++ b/backend/src/app/exceptions.py
@@ -1,0 +1,11 @@
+class EntityDuplicatedError(Exception):
+    def __init__(
+        self, action: str, user_id: int, entity_name: str, entity_id: int | str
+    ):
+        self.action = action
+        self.user_id = user_id
+        self.entity_name = entity_name
+        self.entity_id = entity_id
+        super().__init__(
+            f"{action} failed — duplicate {entity_name.lower()}: {entity_id!r}"
+        )

--- a/backend/src/tests/conftest.py
+++ b/backend/src/tests/conftest.py
@@ -18,7 +18,6 @@ def parse_cookies(cookies: list[str], name: str) -> str | None:
 
 def get_cookie_value(response: Response, name: str):
     cookies = response.headers.getlist("Set-Cookie")
-    print(cookies)
     return parse_cookies(cookies, name)
 
 
@@ -172,7 +171,6 @@ def create_list_authors_articles(auth_client, list_authors, list_articles):
         assert r.status_code == 201
     for article in list_articles:
         r = auth_client.post("/articles", json=article)
-        print(r.get_json())
         assert r.status_code == 201
 
 
@@ -202,6 +200,21 @@ def mock_article():
         "liked": False,
         "author": "A famous author",
         "tags": ["Science-fiction"],
+    }
+
+
+@pytest.fixture()
+def mock_article_2():
+    return {
+        "title": "Another article",
+        "url": "https://example.com/article-2",
+        "year": 2024,
+        "summary": "A longer summary",
+        "consulted": True,
+        "read_later": True,
+        "liked": True,
+        "author": "Another famous author",
+        "tags": ["Thriller"],
     }
 
 

--- a/backend/src/tests/test_api.py
+++ b/backend/src/tests/test_api.py
@@ -179,3 +179,10 @@ def test_per_user_isolation(client, mock_article):
     assert res3.status_code == 200
     headers3 = get_csrf_header(res3, "access")
     assert len(client.get("/articles", headers=headers3).get_json()) == 1
+
+
+def test_duplicated_url(auth_client, article, mock_article_2):
+    mock_article_2["url"] = article["url"]
+    res = auth_client.post("/articles", json=mock_article_2)
+    assert res.status_code == 409
+    assert "duplicate" in res.get_json()["error"]


### PR DESCRIPTION
## Description

This PR introduces a small domain exception for duplicate entities and uses it to handle duplicate article URLs on create/update.

## Changes
- Add `backend/src/app/exceptions.py` with EntityDuplicatedError.
- Register a new global handler that logs a warning and returns a 409 Conflict error.
- In add_article and edit_article, remove the previous inline logging + jsonify response, and raises the new exception instead.
- Add type hints on  routes.
- Add test_duplicated_url.
- Remove debug print calls from `conftest.py`.