### PR TITLE
Persist theme preference across browser sessions

### DIFF
--- a/frontend/src/contexts/ThemeContext.tsx
+++ b/frontend/src/contexts/ThemeContext.tsx
@@ -7,14 +7,14 @@ const ThemeContext = createContext<ThemeContextValue | null>(null);
 
 export function ThemeProvider({ children }: { children: React.ReactNode }) {
   const [theme, setTheme] = useState<Theme>(() => {
-    const saved = sessionStorage.getItem('theme');
+    const saved = localStorage.getItem('theme');
     if (saved === 'light' || saved === 'dark') return saved;
     return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
   });
 
   useEffect(() => {
     document.documentElement.classList.toggle('dark', theme === 'dark');
-    sessionStorage.setItem('theme', theme);
+    localStorage.setItem('theme', theme);
   }, [theme]);
 
   const toggle = () => setTheme((t) => (t === 'dark' ? 'light' : 'dark'));


### PR DESCRIPTION
This PR updates the theme persistence logic in ThemeProvider to use localStorage instead of sessionStorage.

Previously, the selected theme was only stored for the current browser session. As a result, when users closed the tab or browser window, their preference was lost .

By switching to localStorage, the user’s selected theme is now preserved.

Changes made:

Replaced sessionStorage.getItem('theme') with localStorage.getItem('theme')
Replaced sessionStorage.setItem('theme', theme) with localStorage.setItem('theme', theme)

Result:

Users who choose dark or light mode will keep that preference even after closing and reopening the browser.