### PR TITLE
21 feat automatically scrap articles metadata

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -7,3 +7,5 @@ gunicorn==26.0.0
 psycopg[binary]==3.3.4
 pydantic==2.13.4
 python-dotenv==1.2.2
+beautifulsoup4==4.14.3
+requests==2.34.2

--- a/backend/src/app/blueprints/articles.py
+++ b/backend/src/app/blueprints/articles.py
@@ -9,7 +9,7 @@ from app.database import db
 from app.decorators import get_user_id, validate_json
 from app.exceptions import EntityDuplicatedError
 from app.models import Article, Author
-from app.parser import get_document, get_title
+from app.parser import get_author, get_document, get_title
 from app.schemas import ArticleSchema, BasicSchema, IDSchema
 from app.services import (
     associate_tags,
@@ -143,4 +143,5 @@ def parse_article(data: dict[str, Any]):
     url = schema.name
     doc = get_document(url)
     title = get_title(doc)
-    return jsonify({"title": title}), 200
+    author = get_author(doc)
+    return jsonify({"title": title, "author": author}), 200

--- a/backend/src/app/blueprints/articles.py
+++ b/backend/src/app/blueprints/articles.py
@@ -9,7 +9,7 @@ from app.database import db
 from app.decorators import get_user_id, validate_json
 from app.exceptions import EntityDuplicatedError
 from app.models import Article, Author
-from app.parser import get_author, get_document, get_title
+from app.parser import get_author, get_date, get_document, get_title
 from app.schemas import ArticleSchema, BasicSchema, IDSchema
 from app.services import (
     associate_tags,
@@ -144,4 +144,5 @@ def parse_article(data: dict[str, Any]):
     doc = get_document(url)
     title = get_title(doc)
     author = get_author(doc)
-    return jsonify({"title": title, "author": author}), 200
+    date = get_date(doc)
+    return jsonify({"title": title, "author": author, "date": date}), 200

--- a/backend/src/app/blueprints/articles.py
+++ b/backend/src/app/blueprints/articles.py
@@ -9,7 +9,7 @@ from app.database import db
 from app.decorators import get_user_id, validate_json
 from app.exceptions import EntityDuplicatedError
 from app.models import Article, Author
-from app.parser import get_author, get_date, get_document, get_title
+from app.parser import MetadataParser
 from app.schemas import ArticleSchema, BasicSchema, IDSchema
 from app.services import (
     associate_tags,
@@ -141,8 +141,8 @@ def delete_articles(data: dict[str, Any], user_id: int):
 def parse_article(data: dict[str, Any]):
     schema = BasicSchema.model_validate(data)
     url = schema.name
-    doc = get_document(url)
-    title = get_title(doc)
-    author = get_author(doc)
-    date = get_date(doc)
-    return jsonify({"title": title, "author": author, "date": date}), 200
+    parser = MetadataParser(url)
+    parser.parse()
+    return jsonify(
+        {"title": parser.title, "author": parser.author, "date": parser.date}
+    ), 200

--- a/backend/src/app/blueprints/articles.py
+++ b/backend/src/app/blueprints/articles.py
@@ -9,7 +9,8 @@ from app.database import db
 from app.decorators import get_user_id, validate_json
 from app.exceptions import EntityDuplicatedError
 from app.models import Article, Author
-from app.schemas import ArticleSchema, IDSchema
+from app.parser import get_document, get_title
+from app.schemas import ArticleSchema, BasicSchema, IDSchema
 from app.services import (
     associate_tags,
     check_url_uniqueness,
@@ -132,3 +133,14 @@ def delete_articles(data: dict[str, Any], user_id: int):
         ),
         200,
     )
+
+
+@articles_bp.route("/metadata", methods=["POST"])
+@validate_json
+@jwt_required()
+def parse_article(data: dict[str, Any]):
+    schema = BasicSchema.model_validate(data)
+    url = schema.name
+    doc = get_document(url)
+    title = get_title(doc)
+    return jsonify({"title": title}), 200

--- a/backend/src/app/blueprints/articles.py
+++ b/backend/src/app/blueprints/articles.py
@@ -144,5 +144,10 @@ def parse_article(data: dict[str, Any]):
     parser = MetadataParser(url)
     parser.parse()
     return jsonify(
-        {"title": parser.title, "author": parser.author, "date": parser.date}
+        {
+            "title": parser.title,
+            "author": parser.author,
+            "date": parser.date,
+            "url": url,
+        }
     ), 200

--- a/backend/src/app/parser.py
+++ b/backend/src/app/parser.py
@@ -1,127 +1,144 @@
+from typing import Any
+
 import requests
 from bs4 import BeautifulSoup
 from bs4.element import Tag
 
-
-def get_document(url: str) -> BeautifulSoup:
-    headers = {"User-Agent": "ArticleManager/1.0"}
-    res = requests.get(url, headers=headers, timeout=10)
-    res.raise_for_status()
-    return BeautifulSoup(res.text, "html.parser")
+type Candidate = dict[str, Any]
 
 
-def extract_text(tag: Tag | None, location: str) -> str | None:
-    if not tag:
+class MetadataParser:
+    def __init__(self, url: str):
+        self.url = url
+        self.doc: BeautifulSoup | None = None
+        self.title = ""
+        self.author = ""
+        self.date = ""
+
+    def parse(self):
+        self.get_document(self.url)
+        self.get_title()
+        self.get_author()
+        self.get_date()
+
+    @staticmethod
+    def get_attribute(
+        candidates: list[Candidate], html_doc: BeautifulSoup | None
+    ) -> str:
+        if not html_doc:
+            return ""
+        for candidate in candidates:
+            tag = html_doc.find(candidate["name"], **candidate.get("kwargs", {}))
+            text = MetadataParser.extract_text(tag, candidate["location"])
+            element = MetadataParser.clean_text(text)
+            if element:
+                return element
         return ""
-    if location == "content":
-        content = tag.get("content")
-        if content and isinstance(content, str):
-            return content
-        return ""
-    if location == "datetime":
-        datetime_value = tag.get("datetime")
-        if datetime_value and isinstance(datetime_value, str):
-            return datetime_value
-        return ""
-    return tag.get_text()
 
+    @staticmethod
+    def extract_text(tag: Tag | None, location: str) -> str | None:
+        if not tag:
+            return ""
+        if location == "content":
+            content = tag.get("content")
+            if content and isinstance(content, str):
+                return content
+            return ""
+        if location == "datetime":
+            datetime_value = tag.get("datetime")
+            if datetime_value and isinstance(datetime_value, str):
+                return datetime_value
+            return ""
+        return tag.get_text()
 
-def clean_text(text: str | None) -> str:
-    if not text:
-        return ""
-    return text.strip()
+    @staticmethod
+    def clean_text(text: str | None) -> str:
+        if not text:
+            return ""
+        return text.strip()
 
+    def get_document(self, url: str) -> None:
+        headers = {"User-Agent": "ArticleManager/1.0"}
+        res = requests.get(url, headers=headers, timeout=10)
+        res.raise_for_status()
+        self.doc = BeautifulSoup(res.text, "html.parser")
 
-def get_title(html_doc: BeautifulSoup) -> str:
-    candidates = [
-        {"name": "meta", "kwargs": {"property": "og:title"}, "location": "content"},
-        {
-            "name": "meta",
-            "kwargs": {"attrs": {"name": "twitter:title"}},
-            "location": "content",
-        },
-        {"name": "title", "location": "text"},
-        {"name": "h1", "location": "text"},
-    ]
+    def get_title(self) -> None:
+        candidates = [
+            {"name": "meta", "kwargs": {"property": "og:title"}, "location": "content"},
+            {
+                "name": "meta",
+                "kwargs": {"attrs": {"name": "twitter:title"}},
+                "location": "content",
+            },
+            {"name": "title", "location": "text"},
+            {"name": "h1", "location": "text"},
+        ]
+        self.title = MetadataParser.get_attribute(candidates, self.doc)
 
-    for candidate in candidates:
-        tag = html_doc.find(candidate["name"], **candidate.get("kwargs", {}))
-        text = extract_text(tag, candidate["location"])
-        title = clean_text(text)
-        if title:
-            return title
+    def get_author(self) -> None:
+        candidates = [
+            {
+                "name": "meta",
+                "kwargs": {"attrs": {"name": "author"}},
+                "location": "content",
+            },
+            {
+                "name": "meta",
+                "kwargs": {"property": "article:author"},
+                "location": "content",
+            },
+            {"name": True, "kwargs": {"attrs": {"rel": "author"}}, "location": "text"},
+            {
+                "name": True,
+                "kwargs": {"attrs": {"class": "author"}},
+                "location": "text",
+            },
+            {
+                "name": True,
+                "kwargs": {"attrs": {"class": "byline"}},
+                "location": "text",
+            },
+        ]
+        self.author = self.get_attribute(candidates, self.doc)
 
-    return ""
-
-
-def get_author(html_doc: BeautifulSoup) -> str:
-    candidates = [
-        {
-            "name": "meta",
-            "kwargs": {"attrs": {"name": "author"}},
-            "location": "content",
-        },
-        {
-            "name": "meta",
-            "kwargs": {"property": "article:author"},
-            "location": "content",
-        },
-        {"name": True, "kwargs": {"attrs": {"rel": "author"}}, "location": "text"},
-        {"name": True, "kwargs": {"attrs": {"class": "author"}}, "location": "text"},
-        {"name": True, "kwargs": {"attrs": {"class": "byline"}}, "location": "text"},
-    ]
-
-    for candidate in candidates:
-        tag = html_doc.find(candidate["name"], **candidate.get("kwargs", {}))
-        text = extract_text(tag, candidate["location"])
-        title = clean_text(text)
-        if title:
-            return title
-
-    return ""
-
-
-def get_date(html_doc: BeautifulSoup) -> str:
-    candidates = [
-        {
-            "name": "meta",
-            "kwargs": {"property": "article:published_time"},
-            "location": "content",
-        },
-        {"name": "meta", "kwargs": {"attrs": {"name": "date"}}, "location": "content"},
-        {
-            "name": "meta",
-            "kwargs": {"attrs": {"name": "pubdate"}},
-            "location": "content",
-        },
-        {
-            "name": "meta",
-            "kwargs": {"attrs": {"name": "publish_date"}},
-            "location": "content",
-        },
-        {
-            "name": "meta",
-            "kwargs": {"attrs": {"name": "publication_date"}},
-            "location": "content",
-        },
-        {
-            "name": "meta",
-            "kwargs": {"attrs": {"itemprop": "datePublished"}},
-            "location": "content",
-        },
-        {
-            "name": "time",
-            "kwargs": {"attrs": {"datetime": True}},
-            "location": "datetime",
-        },
-        {"name": "time", "location": "text"},
-    ]
-
-    for candidate in candidates:
-        tag = html_doc.find(candidate["name"], **candidate.get("kwargs", {}))
-        text = extract_text(tag, candidate["location"])
-        title = clean_text(text)
-        if title:
-            return title
-
-    return ""
+    def get_date(self) -> None:
+        candidates = [
+            {
+                "name": "meta",
+                "kwargs": {"property": "article:published_time"},
+                "location": "content",
+            },
+            {
+                "name": "meta",
+                "kwargs": {"attrs": {"name": "date"}},
+                "location": "content",
+            },
+            {
+                "name": "meta",
+                "kwargs": {"attrs": {"name": "pubdate"}},
+                "location": "content",
+            },
+            {
+                "name": "meta",
+                "kwargs": {"attrs": {"name": "publish_date"}},
+                "location": "content",
+            },
+            {
+                "name": "meta",
+                "kwargs": {"attrs": {"name": "publication_date"}},
+                "location": "content",
+            },
+            {
+                "name": "meta",
+                "kwargs": {"attrs": {"itemprop": "datePublished"}},
+                "location": "content",
+            },
+            {
+                "name": "time",
+                "kwargs": {"attrs": {"datetime": True}},
+                "location": "datetime",
+            },
+            {"name": "time", "location": "text"},
+        ]
+        self.date = self.get_attribute(candidates, self.doc)

--- a/backend/src/app/parser.py
+++ b/backend/src/app/parser.py
@@ -18,6 +18,11 @@ def extract_text(tag: Tag | None, location: str) -> str | None:
         if content and isinstance(content, str):
             return content
         return ""
+    if location == "datetime":
+        datetime_value = tag.get("datetime")
+        if datetime_value and isinstance(datetime_value, str):
+            return datetime_value
+        return ""
     return tag.get_text()
 
 
@@ -64,6 +69,52 @@ def get_author(html_doc: BeautifulSoup) -> str:
         {"name": True, "kwargs": {"attrs": {"rel": "author"}}, "location": "text"},
         {"name": True, "kwargs": {"attrs": {"class": "author"}}, "location": "text"},
         {"name": True, "kwargs": {"attrs": {"class": "byline"}}, "location": "text"},
+    ]
+
+    for candidate in candidates:
+        tag = html_doc.find(candidate["name"], **candidate.get("kwargs", {}))
+        text = extract_text(tag, candidate["location"])
+        title = clean_text(text)
+        if title:
+            return title
+
+    return ""
+
+
+def get_date(html_doc: BeautifulSoup) -> str:
+    candidates = [
+        {
+            "name": "meta",
+            "kwargs": {"property": "article:published_time"},
+            "location": "content",
+        },
+        {"name": "meta", "kwargs": {"attrs": {"name": "date"}}, "location": "content"},
+        {
+            "name": "meta",
+            "kwargs": {"attrs": {"name": "pubdate"}},
+            "location": "content",
+        },
+        {
+            "name": "meta",
+            "kwargs": {"attrs": {"name": "publish_date"}},
+            "location": "content",
+        },
+        {
+            "name": "meta",
+            "kwargs": {"attrs": {"name": "publication_date"}},
+            "location": "content",
+        },
+        {
+            "name": "meta",
+            "kwargs": {"attrs": {"itemprop": "datePublished"}},
+            "location": "content",
+        },
+        {
+            "name": "time",
+            "kwargs": {"attrs": {"datetime": True}},
+            "location": "datetime",
+        },
+        {"name": "time", "location": "text"},
     ]
 
     for candidate in candidates:

--- a/backend/src/app/parser.py
+++ b/backend/src/app/parser.py
@@ -3,11 +3,11 @@ from bs4 import BeautifulSoup
 from bs4.element import Tag
 
 
-def get_document(url: str) -> str:
+def get_document(url: str) -> BeautifulSoup:
     headers = {"User-Agent": "ArticleManager/1.0"}
     res = requests.get(url, headers=headers, timeout=10)
     res.raise_for_status()
-    return res.text
+    return BeautifulSoup(res.text, "html.parser")
 
 
 def extract_text(tag: Tag | None, location: str) -> str | None:
@@ -27,9 +27,7 @@ def clean_text(text: str | None) -> str:
     return text.strip()
 
 
-def get_title(html_doc: str) -> str:
-    soup = BeautifulSoup(html_doc, "html.parser")
-
+def get_title(html_doc: BeautifulSoup) -> str:
     candidates = [
         {"name": "meta", "kwargs": {"property": "og:title"}, "location": "content"},
         {
@@ -42,7 +40,34 @@ def get_title(html_doc: str) -> str:
     ]
 
     for candidate in candidates:
-        tag = soup.find(candidate["name"], **candidate.get("kwargs", {}))
+        tag = html_doc.find(candidate["name"], **candidate.get("kwargs", {}))
+        text = extract_text(tag, candidate["location"])
+        title = clean_text(text)
+        if title:
+            return title
+
+    return ""
+
+
+def get_author(html_doc: BeautifulSoup) -> str:
+    candidates = [
+        {
+            "name": "meta",
+            "kwargs": {"attrs": {"name": "author"}},
+            "location": "content",
+        },
+        {
+            "name": "meta",
+            "kwargs": {"property": "article:author"},
+            "location": "content",
+        },
+        {"name": True, "kwargs": {"attrs": {"rel": "author"}}, "location": "text"},
+        {"name": True, "kwargs": {"attrs": {"class": "author"}}, "location": "text"},
+        {"name": True, "kwargs": {"attrs": {"class": "byline"}}, "location": "text"},
+    ]
+
+    for candidate in candidates:
+        tag = html_doc.find(candidate["name"], **candidate.get("kwargs", {}))
         text = extract_text(tag, candidate["location"])
         title = clean_text(text)
         if title:

--- a/backend/src/app/parser.py
+++ b/backend/src/app/parser.py
@@ -1,0 +1,51 @@
+import requests
+from bs4 import BeautifulSoup
+from bs4.element import Tag
+
+
+def get_document(url: str) -> str:
+    headers = {"User-Agent": "ArticleManager/1.0"}
+    res = requests.get(url, headers=headers, timeout=10)
+    res.raise_for_status()
+    return res.text
+
+
+def extract_text(tag: Tag | None, location: str) -> str | None:
+    if not tag:
+        return ""
+    if location == "content":
+        content = tag.get("content")
+        if content and isinstance(content, str):
+            return content
+        return ""
+    return tag.get_text()
+
+
+def clean_text(text: str | None) -> str:
+    if not text:
+        return ""
+    return text.strip()
+
+
+def get_title(html_doc: str) -> str:
+    soup = BeautifulSoup(html_doc, "html.parser")
+
+    candidates = [
+        {"name": "meta", "kwargs": {"property": "og:title"}, "location": "content"},
+        {
+            "name": "meta",
+            "kwargs": {"attrs": {"name": "twitter:title"}},
+            "location": "content",
+        },
+        {"name": "title", "location": "text"},
+        {"name": "h1", "location": "text"},
+    ]
+
+    for candidate in candidates:
+        tag = soup.find(candidate["name"], **candidate.get("kwargs", {}))
+        text = extract_text(tag, candidate["location"])
+        title = clean_text(text)
+        if title:
+            return title
+
+    return ""

--- a/backend/src/tests/fixtures/parser/h1_fallback.html
+++ b/backend/src/tests/fixtures/parser/h1_fallback.html
@@ -3,5 +3,6 @@
   <head></head>
   <body>
     <h1>The Lesson to Unlearn</h1>
+    <span class="byline">Paul Graham</span>
   </body>
 </html>

--- a/backend/src/tests/fixtures/parser/h1_fallback.html
+++ b/backend/src/tests/fixtures/parser/h1_fallback.html
@@ -4,5 +4,6 @@
   <body>
     <h1>The Lesson to Unlearn</h1>
     <span class="byline">Paul Graham</span>
+    <time datetime="2019-01-01">January 1, 2019</time>
   </body>
 </html>

--- a/backend/src/tests/fixtures/parser/h1_fallback.html
+++ b/backend/src/tests/fixtures/parser/h1_fallback.html
@@ -1,0 +1,7 @@
+<!doctype html>
+<html lang="en">
+  <head></head>
+  <body>
+    <h1>The Lesson to Unlearn</h1>
+  </body>
+</html>

--- a/backend/src/tests/fixtures/parser/og_title.html
+++ b/backend/src/tests/fixtures/parser/og_title.html
@@ -1,0 +1,10 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta property="og:title" content="Different Worlds">
+    <title>Fallback title should not be used</title>
+  </head>
+  <body>
+    <h1>Fallback heading should not be used</h1>
+  </body>
+</html>

--- a/backend/src/tests/fixtures/parser/og_title.html
+++ b/backend/src/tests/fixtures/parser/og_title.html
@@ -3,6 +3,7 @@
   <head>
     <meta property="og:title" content="Different Worlds">
     <meta name="author" content="Scott Alexander">
+    <meta property="article:published_time" content="2017-10-02">
     <title>Fallback title should not be used</title>
   </head>
   <body>

--- a/backend/src/tests/fixtures/parser/og_title.html
+++ b/backend/src/tests/fixtures/parser/og_title.html
@@ -2,6 +2,7 @@
 <html lang="en">
   <head>
     <meta property="og:title" content="Different Worlds">
+    <meta name="author" content="Scott Alexander">
     <title>Fallback title should not be used</title>
   </head>
   <body>

--- a/backend/src/tests/fixtures/parser/title_tag.html
+++ b/backend/src/tests/fixtures/parser/title_tag.html
@@ -4,6 +4,7 @@
     <title>Why Cryonics Makes Sense</title>
   </head>
   <body>
+    <a href="/author/tim-urban" rel="author">Tim Urban</a>
     <h1>Fallback heading should not be used</h1>
   </body>
 </html>

--- a/backend/src/tests/fixtures/parser/title_tag.html
+++ b/backend/src/tests/fixtures/parser/title_tag.html
@@ -1,0 +1,9 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <title>Why Cryonics Makes Sense</title>
+  </head>
+  <body>
+    <h1>Fallback heading should not be used</h1>
+  </body>
+</html>

--- a/backend/src/tests/fixtures/parser/title_tag.html
+++ b/backend/src/tests/fixtures/parser/title_tag.html
@@ -1,6 +1,7 @@
 <!doctype html>
 <html lang="en">
   <head>
+    <meta itemprop="datePublished" content="2016-03-18">
     <title>Why Cryonics Makes Sense</title>
   </head>
   <body>

--- a/backend/src/tests/fixtures/parser/twitter_title.html
+++ b/backend/src/tests/fixtures/parser/twitter_title.html
@@ -2,6 +2,7 @@
 <html lang="en">
   <head>
     <meta name="twitter:title" content="What the humans like is responsiveness">
+    <meta property="article:author" content="Sasha Chapin">
     <title>Fallback title should not be used</title>
   </head>
   <body>

--- a/backend/src/tests/fixtures/parser/twitter_title.html
+++ b/backend/src/tests/fixtures/parser/twitter_title.html
@@ -3,6 +3,7 @@
   <head>
     <meta name="twitter:title" content="What the humans like is responsiveness">
     <meta property="article:author" content="Sasha Chapin">
+    <meta name="date" content="2023-07-12">
     <title>Fallback title should not be used</title>
   </head>
   <body>

--- a/backend/src/tests/fixtures/parser/twitter_title.html
+++ b/backend/src/tests/fixtures/parser/twitter_title.html
@@ -1,0 +1,10 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta name="twitter:title" content="What the humans like is responsiveness">
+    <title>Fallback title should not be used</title>
+  </head>
+  <body>
+    <h1>Fallback heading should not be used</h1>
+  </body>
+</html>

--- a/backend/src/tests/test_parser.py
+++ b/backend/src/tests/test_parser.py
@@ -7,19 +7,20 @@ FIXTURES_DIR = Path(__file__).parent / "fixtures" / "parser"
 
 
 @pytest.mark.parametrize(
-    "fixture_name, title, author",
+    "fixture_name, title, author, date",
     [
-        ("og_title.html", "Different Worlds", "Scott Alexander"),
+        ("og_title.html", "Different Worlds", "Scott Alexander", "2017-10-02"),
         (
             "twitter_title.html",
             "What the humans like is responsiveness",
             "Sasha Chapin",
+            "2023-07-12",
         ),
-        ("title_tag.html", "Why Cryonics Makes Sense", "Tim Urban"),
-        ("h1_fallback.html", "The Lesson to Unlearn", "Paul Graham"),
+        ("title_tag.html", "Why Cryonics Makes Sense", "Tim Urban", "2016-03-18"),
+        ("h1_fallback.html", "The Lesson to Unlearn", "Paul Graham", "2019-01-01"),
     ],
 )
-def test_parse_title(auth_client, monkeypatch, fixture_name, title, author):
+def test_parse_metadata(auth_client, monkeypatch, fixture_name, title, author, date):
     html = (FIXTURES_DIR / fixture_name).read_text(encoding="utf-8")
     response = SimpleNamespace(text=html, raise_for_status=lambda: None)
     monkeypatch.setattr("app.parser.requests.get", lambda *args, **kwargs: response)
@@ -29,3 +30,4 @@ def test_parse_title(auth_client, monkeypatch, fixture_name, title, author):
     json = res.get_json()
     assert json["title"] == title
     assert json["author"] == author
+    assert json["date"] == date

--- a/backend/src/tests/test_parser.py
+++ b/backend/src/tests/test_parser.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
@@ -6,19 +7,25 @@ FIXTURES_DIR = Path(__file__).parent / "fixtures" / "parser"
 
 
 @pytest.mark.parametrize(
-    "fixture_name, title",
+    "fixture_name, title, author",
     [
-        ("og_title.html", "Different Worlds"),
-        ("twitter_title.html", "What the humans like is responsiveness"),
-        ("title_tag.html", "Why Cryonics Makes Sense"),
-        ("h1_fallback.html", "The Lesson to Unlearn"),
+        ("og_title.html", "Different Worlds", "Scott Alexander"),
+        (
+            "twitter_title.html",
+            "What the humans like is responsiveness",
+            "Sasha Chapin",
+        ),
+        ("title_tag.html", "Why Cryonics Makes Sense", "Tim Urban"),
+        ("h1_fallback.html", "The Lesson to Unlearn", "Paul Graham"),
     ],
 )
-def test_parse_title(auth_client, monkeypatch, fixture_name, title):
+def test_parse_title(auth_client, monkeypatch, fixture_name, title, author):
     html = (FIXTURES_DIR / fixture_name).read_text(encoding="utf-8")
-    monkeypatch.setattr("app.blueprints.articles.get_document", lambda _url: html)
+    response = SimpleNamespace(text=html, raise_for_status=lambda: None)
+    monkeypatch.setattr("app.parser.requests.get", lambda *args, **kwargs: response)
 
     res = auth_client.post("/articles/metadata", json={"name": "https://example.com"})
     assert res.status_code == 200
     json = res.get_json()
     assert json["title"] == title
+    assert json["author"] == author

--- a/backend/src/tests/test_parser.py
+++ b/backend/src/tests/test_parser.py
@@ -1,20 +1,24 @@
+from pathlib import Path
+
 import pytest
+
+FIXTURES_DIR = Path(__file__).parent / "fixtures" / "parser"
 
 
 @pytest.mark.parametrize(
-    "url, title",
+    "fixture_name, title",
     [
-        ("https://slatestarcodex.com/2017/10/02/different-worlds/", "Different Worlds"),
-        (
-            "https://sashachapin.substack.com/p/what-the-humans-like-is-responsiveness",
-            "What the humans like is responsiveness",
-        ),
-        ("https://waitbutwhy.com/2016/03/cryonics.html", "Why Cryonics Makes Sense"),
-        ("https://paulgraham.com/lesson.html", "The Lesson to Unlearn"),
+        ("og_title.html", "Different Worlds"),
+        ("twitter_title.html", "What the humans like is responsiveness"),
+        ("title_tag.html", "Why Cryonics Makes Sense"),
+        ("h1_fallback.html", "The Lesson to Unlearn"),
     ],
 )
-def test_parse_title(auth_client, url, title):
-    res = auth_client.post("/articles/metadata", json={"name": url})
+def test_parse_title(auth_client, monkeypatch, fixture_name, title):
+    html = (FIXTURES_DIR / fixture_name).read_text(encoding="utf-8")
+    monkeypatch.setattr("app.blueprints.articles.get_document", lambda _url: html)
+
+    res = auth_client.post("/articles/metadata", json={"name": "https://example.com"})
     assert res.status_code == 200
     json = res.get_json()
     assert json["title"] == title

--- a/backend/src/tests/test_parser.py
+++ b/backend/src/tests/test_parser.py
@@ -1,0 +1,20 @@
+import pytest
+
+
+@pytest.mark.parametrize(
+    "url, title",
+    [
+        ("https://slatestarcodex.com/2017/10/02/different-worlds/", "Different Worlds"),
+        (
+            "https://sashachapin.substack.com/p/what-the-humans-like-is-responsiveness",
+            "What the humans like is responsiveness",
+        ),
+        ("https://waitbutwhy.com/2016/03/cryonics.html", "Why Cryonics Makes Sense"),
+        ("https://paulgraham.com/lesson.html", "The Lesson to Unlearn"),
+    ],
+)
+def test_parse_title(auth_client, url, title):
+    res = auth_client.post("/articles/metadata", json={"name": url})
+    assert res.status_code == 200
+    json = res.get_json()
+    assert json["title"] == title

--- a/frontend/src/api/entities.ts
+++ b/frontend/src/api/entities.ts
@@ -1,6 +1,6 @@
 import axios from 'axios';
 import { API_URLS } from '../constants/constants';
-import type { Article, AuthorStat, Credentials, Message } from '../constants/types';
+import type { Article, AuthorStat, Credentials, Message, ParsedMetadata } from '../constants/types';
 import {
   MessageSchema,
   DeletedArticlesSchema,
@@ -10,6 +10,7 @@ import {
   AuthorStatSchema,
   ArticleSchema,
   ArticlesSchema,
+  ParsedMetadataSchema,
 } from '../constants/schema';
 import { getCookie, normalizeEntityNames } from '../helpers/helpers';
 
@@ -109,6 +110,13 @@ export const articlesApi = {
     });
     const response = DeletedArticlesSchema.parse(data);
     return response.count;
+  },
+  parse: async (url: string): Promise<ParsedMetadata> => {
+    const { data } = await apiClient.post(API_URLS.PARSE, {
+      name: url,
+    });
+    const response = ParsedMetadataSchema.parse(data);
+    return response;
   },
 };
 

--- a/frontend/src/components/features/AddButton.tsx
+++ b/frontend/src/components/features/AddButton.tsx
@@ -4,7 +4,6 @@ import { Article } from '../../constants/types';
 import { useCreateArticle, useParsing } from '../../hooks/mutations';
 import ArticleForm from '../forms/ArticleForm';
 import UrlForm from '../forms/UrlForm';
-import { data } from 'react-router-dom';
 import { parseYear } from '../../helpers/helpers';
 
 interface PropsType {

--- a/frontend/src/components/features/AddButton.tsx
+++ b/frontend/src/components/features/AddButton.tsx
@@ -1,40 +1,86 @@
-import { useState, type FunctionComponent } from 'react';
-import { Plus } from 'react-feather';
-import { FormProps, Article } from '../../constants/types';
-import { useCreateArticle } from '../../hooks/mutations';
+import { useState } from 'react';
+import { Loader, Plus } from 'react-feather';
+import { Article } from '../../constants/types';
+import { useCreateArticle, useParsing } from '../../hooks/mutations';
+import ArticleForm from '../forms/ArticleForm';
+import UrlForm from '../forms/UrlForm';
+import { data } from 'react-router-dom';
+import { parseYear } from '../../helpers/helpers';
 
 interface PropsType {
-  FormComponent: FunctionComponent<FormProps>;
   title: string;
-  activeItem: Article;
 }
 
-function AddButton({ FormComponent, title, activeItem }: Readonly<PropsType>) {
-  const { mutate: createArticle, isPending } = useCreateArticle();
+const newArticle: Article = {
+  id: 0,
+  title: '',
+  author: '',
+  url: '',
+  year: new Date().getFullYear(),
+  summary: '',
+  consulted: false,
+  read_later: false,
+  liked: false,
+  tags: [],
+  date_creation: '',
+  date_modification: '',
+};
+
+function AddButton({ title }: Readonly<PropsType>) {
+  const [metadata, setMetadata] = useState({ title: '', author: '', date: '', url: '' });
+  const { mutate: parseArticle, isPending: isParsingPending } = useParsing();
+  const { mutate: createArticle, isPending: isCreationPending } = useCreateArticle();
+  const [modalParse, setModalParse] = useState<boolean>(false);
   const [modalCreate, setModalCreate] = useState<boolean>(false);
+
+  function toggleModalParse() {
+    setModalParse(!modalParse);
+  }
 
   function toggleModalCreate() {
     setModalCreate(!modalCreate);
+  }
+
+  function onParsingDone(url: string) {
+    parseArticle(url, {
+      onSuccess: (data) => {
+        setMetadata(data);
+        setModalParse(false);
+        setModalCreate(true);
+      },
+    });
   }
 
   return (
     <>
       <button
         className="inline-flex items-center gap-2 rounded-xl bg-emerald-100 px-4 py-2.5 text-sm font-semibold text-emerald-700 shadow-sm transition hover:opacity-90 dark:bg-emerald-900/40 dark:text-emerald-300"
-        onClick={toggleModalCreate}
-        disabled={isPending}
+        onClick={toggleModalParse}
+        disabled={isParsingPending || isCreationPending}
       >
         <Plus size={16} />
         Add
       </button>
 
+      {modalParse && <UrlForm isOpen={modalParse} toggle={toggleModalParse} onSave={onParsingDone} title={title} showDeleteButton={false} />}
+      {isParsingPending && (
+        <div
+          className="fixed inset-0 z-[1400] flex flex-col items-center justify-center gap-2 bg-black/40"
+          role="status"
+          aria-live="polite"
+          aria-busy="true"
+        >
+          <Loader className="animate-spin text-white" size={32} aria-hidden="true" />
+          <span className="text-sm font-medium text-white">Parsing article…</span>
+        </div>
+      )}
       {modalCreate && (
-        <FormComponent
+        <ArticleForm
+          activeItem={{ ...newArticle, title: metadata.title, author: metadata.author, url: metadata.url, year: parseYear(metadata.date) }}
           isOpen={modalCreate}
           toggle={toggleModalCreate}
           onSave={createArticle}
           title={title}
-          activeItem={activeItem}
           showDeleteButton={false}
         />
       )}

--- a/frontend/src/components/features/PopupWrapper.tsx
+++ b/frontend/src/components/features/PopupWrapper.tsx
@@ -11,6 +11,7 @@ interface PropsType {
 }
 
 function PopupWrapper({ popup, setPopup, status, children }: Readonly<PropsType>) {
+  const panelMaxHeight = 'min(90dvh, calc(100dvh - 2rem))';
   let statusClasses;
 
   switch (status) {
@@ -44,17 +45,15 @@ function PopupWrapper({ popup, setPopup, status, children }: Readonly<PropsType>
           left: '50%',
           transform: 'translate(-50%, -50%)',
           width: 'min(calc(100vw - 2rem), 28rem)',
-          maxHeight: 'min(90dvh, calc(100dvh - 2rem))',
         }}
       >
-        <Box
-          sx={{
-            outline: 'none',
-            maxHeight: 'inherit',
-            overflow: 'auto',
-          }}
-        >
-          <div id="alert-additional-content-3" className={`${statusClasses} rounded-lg select-none p-4`} role="alert">
+        <Box sx={{ outline: 'none' }}>
+          <div
+            id="alert-additional-content-3"
+            className={`${statusClasses} overflow-y-auto rounded-lg select-none p-4`}
+            style={{ maxHeight: panelMaxHeight }}
+            role="alert"
+          >
             {children}
           </div>
         </Box>

--- a/frontend/src/components/forms/ArticleForm.tsx
+++ b/frontend/src/components/forms/ArticleForm.tsx
@@ -5,7 +5,7 @@ import CreatableSelect from 'react-select/creatable';
 import type { SingleValue } from 'react-select';
 import TagsForm from './TagsForm';
 import { buttonSize, buttonStyle } from '../../constants/constants';
-import { FormProps } from '../../constants/types';
+import { ArticleFormProps } from '../../constants/types';
 import { ArticleSchema } from '../../constants/schema';
 import { useAuthors } from '../../hooks/queries';
 import PopupWrapper from '../features/PopupWrapper';
@@ -13,7 +13,7 @@ import RemoveButton from '../features/RemoveButton';
 
 type AuthorOption = { value: string; label: string };
 
-function ArticleForm({ isOpen, toggle, onSave, title, activeItem, showDeleteButton }: Readonly<FormProps>) {
+function ArticleForm({ isOpen, toggle, onSave, title, activeItem, showDeleteButton }: Readonly<ArticleFormProps>) {
   const currentYear = new Date().getFullYear();
   const [item, setItem] = useState(activeItem);
   const [errors, setErrors] = useState<Record<string, string>>({});

--- a/frontend/src/components/forms/ArticleForm.tsx
+++ b/frontend/src/components/forms/ArticleForm.tsx
@@ -131,6 +131,7 @@ function ArticleForm({ isOpen, toggle, onSave, title, activeItem, showDeleteButt
                 value={item.url}
                 onChange={handleFieldChange}
                 className={inputClassName}
+                autoComplete="off"
                 invalid={errors.url !== undefined && errors.url !== ''}
               />
               {errors.url && <div className="text-sm text-red-500">{errors.url}</div>}

--- a/frontend/src/components/forms/UrlForm.tsx
+++ b/frontend/src/components/forms/UrlForm.tsx
@@ -1,0 +1,65 @@
+import { useState, type ChangeEvent } from 'react';
+import { Input } from 'reactstrap';
+import { buttonSize, buttonStyle } from '../../constants/constants';
+import { UrlFormProps } from '../../constants/types';
+import { ArticleSchema } from '../../constants/schema';
+import PopupWrapper from '../features/PopupWrapper';
+
+const UrlOnlySchema = ArticleSchema.pick({ url: true });
+
+function UrlForm({ isOpen, toggle, onSave, title }: Readonly<UrlFormProps>) {
+  const [url, setUrl] = useState('');
+  const [error, setError] = useState<string | undefined>();
+  const inputClassName =
+    'border-slate-300 bg-white text-slate-900 placeholder:text-slate-500 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-100 dark:placeholder:text-slate-400';
+
+  function handleChange(e: ChangeEvent<HTMLInputElement>): void {
+    setUrl(e.currentTarget.value);
+    setError(undefined);
+  }
+
+  function validateForm(): void {
+    const result = UrlOnlySchema.safeParse({ url });
+
+    if (result.success) {
+      setError(undefined);
+      onSave(result.data.url);
+      return;
+    }
+
+    const issue = result.error.issues.find((i) => i.path[0] === 'url');
+    setError(issue?.message?.trim() ? issue.message : 'Invalid URL');
+  }
+
+  return (
+    <PopupWrapper popup={isOpen} setPopup={toggle} status="neutral">
+      <div className="flex w-100 flex-col space-y-8">
+        <h1 className="text-center text-3xl font-bold dark:text-white">{title}</h1>
+        <form>
+          <div>
+            <label htmlFor="url" className="text-slate-800 dark:text-slate-100">
+              <b>Url</b>
+            </label>
+            <Input
+              type="url"
+              name="url"
+              placeholder="https://example.com/article"
+              value={url}
+              onChange={handleChange}
+              className={inputClassName}
+              invalid={error !== undefined}
+            />
+            {error && <div className="text-sm text-red-500">{error}</div>}
+          </div>
+        </form>
+        <div className="flex w-full justify-center">
+          <button type="button" className={`${buttonStyle.success} ${buttonSize.medium}`} onClick={validateForm}>
+            Save
+          </button>
+        </div>
+      </div>
+    </PopupWrapper>
+  );
+}
+
+export default UrlForm;

--- a/frontend/src/components/forms/UrlForm.tsx
+++ b/frontend/src/components/forms/UrlForm.tsx
@@ -33,7 +33,7 @@ function UrlForm({ isOpen, toggle, onSave, title }: Readonly<UrlFormProps>) {
 
   return (
     <PopupWrapper popup={isOpen} setPopup={toggle} status="neutral">
-      <div className="flex w-100 flex-col space-y-8">
+      <div className="article-form flex w-100 flex-col space-y-8">
         <h1 className="text-center text-3xl font-bold dark:text-white">{title}</h1>
         <form>
           <div>

--- a/frontend/src/components/pages/ArticlesPage.tsx
+++ b/frontend/src/components/pages/ArticlesPage.tsx
@@ -1,12 +1,10 @@
 import { GridColDef } from '@mui/x-data-grid';
 import { Heart } from 'react-feather';
-import { Article } from '../../constants/types';
 import { useArticles } from '../../hooks/queries';
 import AddButton from '../features/AddButton';
 import StatusIcon from '../features/StatusIcon';
 import DataTable from '../layout/DataTable';
 import EditButton from '../features/EditButton';
-import ArticleForm from '../forms/ArticleForm';
 import PageHeader from '../layout/PageHeader';
 
 function ArticlesPage() {
@@ -15,20 +13,6 @@ function ArticlesPage() {
   const likedCount = articles.filter((article) => article.liked).length;
 
   const TITLE_ADD_FORM: string = 'Add article';
-  const newArticle: Article = {
-    id: 0,
-    title: '',
-    author: '',
-    url: '',
-    year: new Date().getFullYear(),
-    summary: '',
-    consulted: false,
-    read_later: false,
-    liked: false,
-    tags: [],
-    date_creation: '',
-    date_modification: '',
-  };
   const COLUMNS: GridColDef[] = [
     {
       field: 'title',
@@ -113,7 +97,7 @@ function ArticlesPage() {
       </PageHeader>
 
       <div className="flex justify-end">
-        <AddButton FormComponent={ArticleForm} title={TITLE_ADD_FORM} activeItem={newArticle} />
+        <AddButton title={TITLE_ADD_FORM} />
       </div>
 
       <div className="overflow-hidden rounded-2xl border border-slate-200/80 bg-white shadow-sm dark:border-slate-700 dark:bg-slate-800">

--- a/frontend/src/constants/constants.ts
+++ b/frontend/src/constants/constants.ts
@@ -2,6 +2,7 @@ const baseURL: string = import.meta.env.VITE_API_BASE_URL ?? 'http://localhost:5
 
 export const API_URLS = {
   ARTICLES: `${baseURL}/articles`,
+  PARSE: `${baseURL}/articles/metadata`,
   AUTHORS: `${baseURL}/authors`,
   TOP_AUTHORS: `${baseURL}/authors/top`,
   TAGS: `${baseURL}/tags`,

--- a/frontend/src/constants/schema.ts
+++ b/frontend/src/constants/schema.ts
@@ -37,6 +37,13 @@ export const ArticleSchema = z.object({
 
 export const ArticlesSchema = z.array(ArticleSchema);
 
+export const ParsedMetadataSchema = z.object({
+  title: z.string(),
+  author: z.string(),
+  date: z.string(),
+  url: z.string(),
+});
+
 const makeDeletedSchema = <T extends z.ZodTypeAny>(itemSchema: T) =>
   z.object({
     deleted: z.array(itemSchema),

--- a/frontend/src/constants/types.tsx
+++ b/frontend/src/constants/types.tsx
@@ -13,6 +13,13 @@ export interface Article {
   date_modification: string;
 }
 
+export interface ParsedMetadata {
+  title: string;
+  author: string;
+  date: string;
+  url: string;
+}
+
 export interface Credentials {
   name: string;
   password: string;
@@ -32,11 +39,18 @@ export type AuthorStat = {
   count: number;
 };
 
-export interface FormProps {
+export interface BaseFormProps {
   isOpen: boolean;
   toggle: () => void;
-  onSave: (item: Article) => void;
   title: string;
-  activeItem: Article;
   showDeleteButton?: boolean;
+}
+
+export interface ArticleFormProps extends BaseFormProps {
+  onSave: (item: Article) => void;
+  activeItem: Article;
+}
+
+export interface UrlFormProps extends BaseFormProps {
+  onSave: (url: string) => void;
 }

--- a/frontend/src/helpers/helpers.ts
+++ b/frontend/src/helpers/helpers.ts
@@ -14,3 +14,11 @@ export function getCookie(name: string): string | undefined {
 export function normalizeEntityNames(entities: Array<string | Entity>): string[] {
   return entities.map((entity) => (typeof entity === 'string' ? entity : entity.name));
 }
+
+export function parseYear(date: string): number {
+  if (!date) {
+    return new Date().getFullYear();
+  }
+
+  return new Date(date).getFullYear();
+}

--- a/frontend/src/hooks/mutations.ts
+++ b/frontend/src/hooks/mutations.ts
@@ -93,3 +93,15 @@ export const useLogout = () => {
     },
   });
 };
+
+export const useParsing = () => {
+  return useMutation({
+    mutationFn: articlesApi.parse,
+    onSuccess: () => {
+      toast.success('Article successfully parsed!');
+    },
+    onError: (err: unknown) => {
+      toast.error(extractErrorMessage(err));
+    },
+  });
+};

--- a/frontend/src/style/index.css
+++ b/frontend/src/style/index.css
@@ -234,10 +234,20 @@ body {
 
 .dark .article-form input.form-control:-webkit-autofill,
 .dark .article-form input.form-control:-webkit-autofill:hover,
-.dark .article-form input.form-control:-webkit-autofill:focus {
+.dark .article-form input.form-control:-webkit-autofill:focus,
+.dark .article-form input.form-control:autofill {
   -webkit-text-fill-color: #e2e8f0;
   -webkit-box-shadow: 0 0 0 1000px #1e293b inset;
+  box-shadow: 0 0 0 1000px #1e293b inset;
   transition: background-color 9999s ease-out 0s;
+}
+
+.dark .article-form input.form-control[type='url'],
+.dark .article-form input.form-control[type='url']:focus {
+  background-color: #1e293b !important;
+  border-color: #475569 !important;
+  color: #e2e8f0 !important;
+  color-scheme: dark;
 }
 
 /* Light mode */


### PR DESCRIPTION
## Description 

This PR mplements the parser to get articles's metadata automatically - reducing user's manual effort.

## Changes
- Add a parser service in the backend.
- Make it retrieve the title, author and publishing date of the article.
- Add a new endpoint `/articles/metadata` accepting a url and returning the parsed metadata.
- Add new tests in the backend to verify this feature.
- Update UI to ask for an url only when adding an article before sending it to the backend to parse the metadata.

Closes #21 