### PR TITLE
fix(backend): handle invalid metadata urls

### DIFF
--- a/backend/src/app/blueprints/articles.py
+++ b/backend/src/app/blueprints/articles.py
@@ -1,9 +1,11 @@
 import logging
 from typing import Any
 
+import requests
 from flask import Blueprint, jsonify
 from flask_jwt_extended import jwt_required
 from sqlalchemy import select
+from werkzeug.exceptions import BadRequest
 
 from app.database import db
 from app.decorators import get_user_id, validate_json
@@ -142,7 +144,13 @@ def parse_article(data: dict[str, Any]):
     schema = BasicSchema.model_validate(data)
     url = schema.name
     parser = MetadataParser(url)
-    parser.parse()
+    try:
+        parser.parse()
+    except requests.exceptions.RequestException as error:
+        raise BadRequest(
+            "Unable to fetch metadata from the provided URL. "
+            "Please check that the URL is valid and reachable."
+        ) from error
     return jsonify(
         {
             "title": parser.title,

--- a/backend/src/tests/test_parser.py
+++ b/backend/src/tests/test_parser.py
@@ -2,6 +2,7 @@ from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
+import requests
 
 FIXTURES_DIR = Path(__file__).parent / "fixtures" / "parser"
 
@@ -31,3 +32,19 @@ def test_parse_metadata(auth_client, monkeypatch, fixture_name, title, author, d
     assert json["title"] == title
     assert json["author"] == author
     assert json["date"] == date
+
+
+def test_parse_metadata_returns_client_error_for_invalid_url(auth_client, monkeypatch):
+    def raise_invalid_url(*args, **kwargs):
+        raise requests.exceptions.InvalidURL("Invalid URL")
+
+    monkeypatch.setattr("app.parser.requests.get", raise_invalid_url)
+
+    res = auth_client.post("/articles/metadata", json={"name": "not-a-url"})
+
+    assert res.status_code == 400
+    assert (
+        res.get_json()["error"]
+        == "Unable to fetch metadata from the provided URL. "
+        "Please check that the URL is valid and reachable."
+    )


### PR DESCRIPTION
## Summary

Closes #63.

This updates the `/articles/metadata` backend endpoint so URL fetch failures from `MetadataParser` no longer bubble up as a generic Flask 500. The route now catches `requests` exceptions raised during metadata parsing and returns the API's existing JSON error shape with a 400 response and a clear message telling the user to check that the URL is valid and reachable.

The successful metadata path is unchanged: valid URLs still parse title, author, date, and URL from the existing `MetadataParser` flow. The catch is kept at the route boundary so the parser can continue raising normal `requests` errors internally while the public API presents a user-facing response for invalid, unreachable, timed-out, or non-2xx metadata fetches.

I added a regression test that simulates an invalid URL by raising `requests.exceptions.InvalidURL` from the existing `requests.get` monkeypatch point and asserts the endpoint returns 400 plus the readable JSON `error` message.

## Verification

- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest` from `backend` in a local `.venv` — 27 passed
- `ruff check src`
- `python -m compileall -q src/app src/tests`
- `git diff --check`
