### PR TITLE
feat: make backend the single source of truth for auth state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ dist/
 # IDE
 .idea/
 .vscode/
+.cursor/
 private/
 
 # TEST (SonarQube)

--- a/backend/src/app/blueprints/auth.py
+++ b/backend/src/app/blueprints/auth.py
@@ -17,6 +17,7 @@ from app.database import db
 from app.decorators import get_user_id, validate_json
 from app.models import User
 from app.schemas import UserSchema
+from app.services import get_entity
 
 logger = logging.getLogger("article_manager.auth")
 
@@ -73,6 +74,15 @@ def login(data: dict[str, Any]):
     set_access_cookies(response, access_token)
     set_refresh_cookies(response, refresh_token)
     return response, 200
+
+
+@auth_bp.route("/session", methods=["GET"])
+@jwt_required()
+@get_user_id
+def session(user_id: int):
+    logger.info("Session verified: user_id=%d", user_id)
+    user = get_entity(user_id, User)
+    return jsonify({"id": user_id, "name": user.name}), 200
 
 
 @auth_bp.route("/refresh", methods=["POST"])

--- a/backend/src/tests/test_api.py
+++ b/backend/src/tests/test_api.py
@@ -1,51 +1,11 @@
 import pytest
 
-from tests.conftest import INVALID_ARTICLE_CASES, get_cookie_value, get_csrf_header
+from tests.conftest import INVALID_ARTICLE_CASES, get_csrf_header
 
 
 def test_health(client):
     res = client.get("/health")
     assert res.status_code == 200
-
-
-def test_register(client):
-    res = client.post("/auth/register", json={"name": "Test", "password": "Test"})
-    assert res.status_code == 201
-    assert get_cookie_value(res, "access_token_cookie")
-    assert get_cookie_value(res, "refresh_token_cookie")
-    assert get_cookie_value(res, "csrf_access_token")
-    assert get_cookie_value(res, "csrf_refresh_token")
-
-
-def test_login(client):
-    client.post("/auth/register", json={"name": "Test", "password": "Test"})
-    res = client.post("/auth/login", json={"name": "Test", "password": "Test"})
-    assert res.status_code == 200
-    assert get_cookie_value(res, "access_token_cookie")
-    assert get_cookie_value(res, "refresh_token_cookie")
-    assert get_cookie_value(res, "csrf_access_token")
-    assert get_cookie_value(res, "csrf_refresh_token")
-
-
-def test_refresh(client):
-    res = client.post("/auth/register", json={"name": "Test", "password": "Test"})
-    headers = get_csrf_header(res, "refresh")
-    res = client.post("/auth/refresh", headers=headers)
-    assert res.status_code == 200
-    assert get_cookie_value(res, "access_token_cookie")
-    assert get_cookie_value(res, "csrf_access_token")
-
-
-def test_logout(auth_client):
-    res = auth_client.post("/auth/logout")
-    assert res.status_code == 200
-    assert not get_cookie_value(res, "access_token_cookie")
-    assert not get_cookie_value(res, "csrf_access_token")
-
-
-def test_method_not_allowed(client):
-    res = client.get("/auth/register")
-    assert res.status_code == 405
 
 
 def test_get_article(auth_client, article):

--- a/backend/src/tests/test_auth.py
+++ b/backend/src/tests/test_auth.py
@@ -1,0 +1,41 @@
+from tests.conftest import get_cookie_value, get_csrf_header
+
+
+def test_register(client):
+    res = client.post("/auth/register", json={"name": "Test", "password": "Test"})
+    assert res.status_code == 201
+    assert get_cookie_value(res, "access_token_cookie")
+    assert get_cookie_value(res, "refresh_token_cookie")
+    assert get_cookie_value(res, "csrf_access_token")
+    assert get_cookie_value(res, "csrf_refresh_token")
+
+
+def test_login(client):
+    client.post("/auth/register", json={"name": "Test", "password": "Test"})
+    res = client.post("/auth/login", json={"name": "Test", "password": "Test"})
+    assert res.status_code == 200
+    assert get_cookie_value(res, "access_token_cookie")
+    assert get_cookie_value(res, "refresh_token_cookie")
+    assert get_cookie_value(res, "csrf_access_token")
+    assert get_cookie_value(res, "csrf_refresh_token")
+
+
+def test_refresh(client):
+    res = client.post("/auth/register", json={"name": "Test", "password": "Test"})
+    headers = get_csrf_header(res, "refresh")
+    res = client.post("/auth/refresh", headers=headers)
+    assert res.status_code == 200
+    assert get_cookie_value(res, "access_token_cookie")
+    assert get_cookie_value(res, "csrf_access_token")
+
+
+def test_logout(auth_client):
+    res = auth_client.post("/auth/logout")
+    assert res.status_code == 200
+    assert not get_cookie_value(res, "access_token_cookie")
+    assert not get_cookie_value(res, "csrf_access_token")
+
+
+def test_method_not_allowed(client):
+    res = client.get("/auth/register")
+    assert res.status_code == 405

--- a/backend/src/tests/test_auth.py
+++ b/backend/src/tests/test_auth.py
@@ -39,3 +39,15 @@ def test_logout(auth_client):
 def test_method_not_allowed(client):
     res = client.get("/auth/register")
     assert res.status_code == 405
+
+
+def test_session_verified(auth_client):
+    res = auth_client.get("/auth/session")
+    assert res.status_code == 200
+    payload = res.get_json()
+    assert payload["name"] == "Test"
+
+
+def test_session_rejected(client):
+    res = client.get("/auth/session")
+    assert res.status_code == 401

--- a/frontend/src/api/entities.ts
+++ b/frontend/src/api/entities.ts
@@ -1,6 +1,6 @@
 import axios from 'axios';
 import { API_URLS } from '../constants/constants';
-import type { Article, AuthorStat, Credentials, Message, ParsedMetadata } from '../constants/types';
+import type { Article, AuthorStat, Credentials, Message, ParsedMetadata, User } from '../constants/types';
 import {
   MessageSchema,
   DeletedArticlesSchema,
@@ -81,6 +81,11 @@ export const authApi = {
       },
     );
     const result = parseWithError(MessageSchema, data);
+    return result;
+  },
+  session: async (): Promise<User> => {
+    const { data } = await apiClient.get(API_URLS.SESSION);
+    const result = parseWithError(EntitySchema, data);
     return result;
   },
   logout: async (): Promise<Message> => {

--- a/frontend/src/api/queryKeys.ts
+++ b/frontend/src/api/queryKeys.ts
@@ -15,6 +15,7 @@ export const queryKeys = {
   },
   auth: {
     all: ['auth'],
+    session: () => [...queryKeys.auth.all, 'session'],
   },
   health: {
     all: ['health'],

--- a/frontend/src/components/layout/ProtectedRoute.tsx
+++ b/frontend/src/components/layout/ProtectedRoute.tsx
@@ -3,10 +3,14 @@ import { Navigate, Outlet } from 'react-router-dom';
 import { useAuth } from '../../contexts/AuthContext';
 
 export function ProtectedRoute() {
-  const { isConnected } = useAuth();
+  const { isConnected, isLoading } = useAuth();
 
-  if (!isConnected) {
+  if (!isConnected && !isLoading) {
     return <Navigate to="/" replace />;
+  }
+
+  if (isLoading) {
+    return null;
   }
 
   return <Outlet />;

--- a/frontend/src/constants/constants.ts
+++ b/frontend/src/constants/constants.ts
@@ -10,6 +10,7 @@ export const API_URLS = {
   LOGOUT: `${baseURL}/auth/logout`,
   REGISTER: `${baseURL}/auth/register`,
   REFRESH: `${baseURL}/auth/refresh`,
+  SESSION: `${baseURL}/auth/session`,
   HEALTH: `${baseURL}/health`,
 };
 

--- a/frontend/src/constants/schema.ts
+++ b/frontend/src/constants/schema.ts
@@ -3,6 +3,7 @@ import * as z from 'zod';
 export const MessageSchema = z.object({
   msg: z.string(),
 });
+
 export const EntitySchema = z.object({
   id: z.int(),
   name: z.string(),

--- a/frontend/src/constants/types.tsx
+++ b/frontend/src/constants/types.tsx
@@ -62,3 +62,8 @@ export interface UrlFormProps extends BaseFormProps {
 }
 
 export type GridPageCardAction = 'liked' | 'readLater';
+
+export interface User {
+  id: number;
+  name: string;
+}

--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -1,8 +1,12 @@
-import { createContext, useContext, useState } from 'react';
+import { createContext, useContext } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
+import { useSession } from '../hooks/queries';
+import { User } from '../constants/types';
 
 interface Auth {
+  user: User | undefined;
   isConnected: boolean;
+  isLoading: boolean;
   login: () => void;
   logout: () => void;
 }
@@ -11,20 +15,19 @@ const AuthContext = createContext<Auth | undefined>(undefined);
 
 export function AuthProvider({ children }: { children: React.ReactNode }) {
   const qc = useQueryClient();
-  const [isConnected, setIsConnected] = useState<boolean>(window.sessionStorage.getItem('isConnected') === 'true');
+  const { data: user, isLoading, refetch } = useSession();
+  const isConnected = !!user;
 
   const login = () => {
-    window.sessionStorage.setItem('isConnected', 'true');
-    setIsConnected(true);
+    refetch();
   };
 
   const logout = () => {
-    window.sessionStorage.setItem('isConnected', 'false');
-    setIsConnected(false);
     qc.clear();
+    refetch();
   };
 
-  return <AuthContext.Provider value={{ isConnected, login, logout }}>{children}</AuthContext.Provider>;
+  return <AuthContext.Provider value={{ user, isConnected, isLoading, login, logout }}>{children}</AuthContext.Provider>;
 }
 
 export function useAuth() {

--- a/frontend/src/hooks/queries.ts
+++ b/frontend/src/hooks/queries.ts
@@ -1,5 +1,5 @@
 import { useQuery } from '@tanstack/react-query';
-import { articlesApi, authorsApi, tagsApi, healthApi } from '../api/entities';
+import { articlesApi, authorsApi, tagsApi, healthApi, authApi } from '../api/entities';
 import { queryKeys } from '../api/queryKeys';
 
 export function useArticles() {
@@ -44,5 +44,13 @@ export function useHealth() {
     queryFn: healthApi.status,
     refetchInterval: 60000,
     staleTime: 60000,
+  });
+}
+
+export function useSession() {
+  return useQuery({
+    queryKey: queryKeys.auth.session(),
+    queryFn: authApi.session,
+    retry: false,
   });
 }


### PR DESCRIPTION
## Problem
There were two sources of truth to determine whether a user was authenticated: the backend validating JWT cookies on each request and the UI storing the auth state in sessionStorage. It could create mismatch where the token would expire but the UI would still consider user as connected.

## Description
This PR makes the backend the single source of truth via GET /auth/session.

## Changes

**Backend**
- Add a new endpoint /session which tells user if they're connected and returns their username.
- Add two tests to check the happy and failure paths of this new endpoint.
- Move all tests related to authentication into a new test file for better separation of concerns.

**Frontend**
- Add a query to fetch the new /session endpoint.
- Link it to TanStack's cache.
- Modify `AuthProvider` to stop relying on sessionStorage and retrieve auth state from the backend instead.
- The provider also exposes the user's info - id and username - which could then be shown (#futur issue).
- `ProtectedRoute` now wait for session checking before redirecting.

