### PR TITLE
feat(frontend): add user menu

### DIFF
--- a/frontend/src/components/forms/ArticleForm.tsx
+++ b/frontend/src/components/forms/ArticleForm.tsx
@@ -8,6 +8,7 @@ import { buttonSize, buttonStyle } from '../../constants/constants';
 import { ArticleFormProps } from '../../constants/types';
 import { ArticleSchema } from '../../constants/schema';
 import { useAuthors } from '../../hooks/queries';
+import { useSettings } from '../../contexts/SettingsContext';
 import PopupWrapper from '../features/PopupWrapper';
 import RemoveButton from '../features/RemoveButton';
 
@@ -18,6 +19,7 @@ function ArticleForm({ isOpen, toggle, onSave, title, activeItem, showDeleteButt
   const [item, setItem] = useState(activeItem);
   const [errors, setErrors] = useState<Record<string, string>>({});
   const { data: authors = [] } = useAuthors();
+  const { requireSummaryOnSave } = useSettings();
   const authorOptions: AuthorOption[] = authors.map((author) => ({ value: author, label: author }));
   const selectedAuthor = authorOptions.find((option) => option.value === item.author) ?? { value: item.author, label: item.author };
   const inputClassName =
@@ -44,21 +46,26 @@ function ArticleForm({ isOpen, toggle, onSave, title, activeItem, showDeleteButt
   function validateForm() {
     const result = ArticleSchema.safeParse(item);
 
-    if (result.success) {
-      setErrors({});
-      onSave(item);
-      toggle();
+    if (!result.success) {
+      const newErrors: Record<string, string> = {};
+      result.error.issues.forEach((issue) => {
+        const key = issue.path[0];
+        if (typeof key === 'string' && newErrors[key] === undefined) {
+          newErrors[key] = issue.message;
+        }
+      });
+      setErrors(newErrors);
       return;
     }
 
-    const newErrors: Record<string, string> = {};
-    result.error.issues.forEach((issue) => {
-      const key = issue.path[0];
-      if (typeof key === 'string' && newErrors[key] === undefined) {
-        newErrors[key] = issue.message;
-      }
-    });
-    setErrors(newErrors);
+    if (requireSummaryOnSave && item.consulted && item.summary.trim() === '') {
+      setErrors({ summary: 'Summary is required' });
+      return;
+    }
+
+    setErrors({});
+    onSave(item);
+    toggle();
   }
 
   return (
@@ -178,7 +185,7 @@ function ArticleForm({ isOpen, toggle, onSave, title, activeItem, showDeleteButt
             </div>
             <div>
               <label htmlFor="summary" className="text-slate-800 dark:text-slate-100">
-                <b>Summary</b>
+                <b>Summary{requireSummaryOnSave ? ' *' : ''}</b>
               </label>
               <Input
                 type="textarea"

--- a/frontend/src/components/layout/NavBar.tsx
+++ b/frontend/src/components/layout/NavBar.tsx
@@ -1,22 +1,16 @@
 import { useState } from 'react';
 import { Link } from 'react-router-dom';
 
-import { Moon, Sun } from 'react-feather';
-
 import { NavTabs } from './NavTabs';
+import { UserMenu } from './UserMenu';
 import AuthForm from '../forms/AuthForm';
 import { buttonSize, buttonStyle } from '../../constants/constants';
 import { useAuth } from '../../contexts/AuthContext';
-import { useTheme, useIsDarkMode } from '../../contexts/ThemeContext';
-import { useLogout } from '../../hooks/mutations';
 
 type AuthMode = 'login' | 'register';
 
 function NavBar() {
-  const { toggle } = useTheme();
-  const isDarkMode = useIsDarkMode();
   const { isConnected } = useAuth();
-  const logoutMutation = useLogout();
   const [authMode, setAuthMode] = useState<AuthMode>('login');
   const [isAuthFormOpen, setIsAuthFormOpen] = useState(false);
 
@@ -36,23 +30,8 @@ function NavBar() {
         </Link>
         <div className="justify-self-center">{isConnected && <NavTabs />}</div>
         <div className="flex items-center justify-end gap-2 justify-self-end">
-          <button
-            onClick={toggle}
-            className="rounded-lg border border-slate-300 p-2 text-slate-600 transition bg-slate-100 hover:text-slate-800 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-200 dark:hover:bg-slate-700"
-            aria-label={isDarkMode ? 'Switch to light mode' : 'Switch to dark mode'}
-            title={isDarkMode ? 'Light mode' : 'Dark mode'}
-          >
-            {isDarkMode ? <Sun size={16} /> : <Moon size={16} />}
-          </button>
-
           {isConnected ? (
-            <button
-              className={`${buttonStyle.error} ${buttonSize.small}`}
-              onClick={() => logoutMutation.mutate()}
-              disabled={logoutMutation.isPending}
-            >
-              Logout
-            </button>
+            <UserMenu />
           ) : (
             <>
               <button className={`${buttonStyle.neutral} ${buttonSize.small}`} onClick={() => openAuthForm('login')}>

--- a/frontend/src/components/layout/UserMenu.tsx
+++ b/frontend/src/components/layout/UserMenu.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState } from 'react';
 import { LogOut, Moon, Sun, User } from 'react-feather';
 
 import { useAuth } from '../../contexts/AuthContext';
+import { useSettings } from '../../contexts/SettingsContext';
 import { useIsDarkMode, useTheme } from '../../contexts/ThemeContext';
 import { useLogout } from '../../hooks/mutations';
 
@@ -9,6 +10,7 @@ export function UserMenu() {
   const { user } = useAuth();
   const { toggle } = useTheme();
   const isDarkMode = useIsDarkMode();
+  const { requireSummaryOnSave, setRequireSummaryOnSave } = useSettings();
   const logoutMutation = useLogout();
   const [isOpen, setIsOpen] = useState(false);
   const menuRef = useRef<HTMLDivElement>(null);
@@ -64,6 +66,23 @@ export function UserMenu() {
       {isOpen && (
         <div role="menu" className="user-menu__panel">
           <div className="user-menu__header">{user.name}</div>
+          <div className="user-menu__divider" />
+          <div className="user-menu__toggle-row">
+            <label htmlFor="require-summary-toggle" className="user-menu__toggle-label">
+              Require summary when saving
+            </label>
+            <button
+              id="require-summary-toggle"
+              type="button"
+              role="menuitemcheckbox"
+              aria-checked={requireSummaryOnSave}
+              aria-label="Require summary when saving an article"
+              className={`user-menu__switch ${requireSummaryOnSave ? 'user-menu__switch--on' : ''}`}
+              onClick={() => setRequireSummaryOnSave(!requireSummaryOnSave)}
+            >
+              <span className="user-menu__switch-thumb" />
+            </button>
+          </div>
           <div className="user-menu__divider" />
           <button type="button" role="menuitem" onClick={handleThemeToggle} className="user-menu__item">
             {isDarkMode ? <Sun size={16} className="text-amber-500" /> : <Moon size={16} className="text-indigo-500" />}

--- a/frontend/src/components/layout/UserMenu.tsx
+++ b/frontend/src/components/layout/UserMenu.tsx
@@ -1,0 +1,87 @@
+import { useEffect, useRef, useState } from 'react';
+import { LogOut, Moon, Sun, User } from 'react-feather';
+
+import { useAuth } from '../../contexts/AuthContext';
+import { useIsDarkMode, useTheme } from '../../contexts/ThemeContext';
+import { useLogout } from '../../hooks/mutations';
+
+export function UserMenu() {
+  const { user } = useAuth();
+  const { toggle } = useTheme();
+  const isDarkMode = useIsDarkMode();
+  const logoutMutation = useLogout();
+  const [isOpen, setIsOpen] = useState(false);
+  const menuRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!isOpen) return;
+
+    function handleClickOutside(event: MouseEvent) {
+      if (menuRef.current && !menuRef.current.contains(event.target as Node)) {
+        setIsOpen(false);
+      }
+    }
+
+    function handleEscape(event: KeyboardEvent) {
+      if (event.key === 'Escape') {
+        setIsOpen(false);
+      }
+    }
+
+    document.addEventListener('mousedown', handleClickOutside);
+    document.addEventListener('keydown', handleEscape);
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+      document.removeEventListener('keydown', handleEscape);
+    };
+  }, [isOpen]);
+
+  function handleThemeToggle() {
+    toggle();
+    setIsOpen(false);
+  }
+
+  function handleLogout() {
+    logoutMutation.mutate();
+    setIsOpen(false);
+  }
+
+  if (!user) return null;
+
+  return (
+    <div ref={menuRef} className="user-menu relative">
+      <button
+        type="button"
+        onClick={() => setIsOpen((open) => !open)}
+        className={`user-menu__trigger ${isOpen ? 'user-menu__trigger--open' : ''}`}
+        aria-haspopup="menu"
+        aria-expanded={isOpen}
+        aria-label={`User menu for ${user.name}`}
+      >
+        <User size={18} className="user-menu__icon" />
+      </button>
+
+      {isOpen && (
+        <div role="menu" className="user-menu__panel">
+          <div className="user-menu__header">{user.name}</div>
+          <div className="user-menu__divider" />
+          <button type="button" role="menuitem" onClick={handleThemeToggle} className="user-menu__item">
+            {isDarkMode ? <Sun size={16} className="text-amber-500" /> : <Moon size={16} className="text-indigo-500" />}
+            {isDarkMode ? 'Light mode' : 'Dark mode'}
+          </button>
+          <div className="user-menu__divider" />
+          <button
+            type="button"
+            role="menuitem"
+            onClick={handleLogout}
+            disabled={logoutMutation.isPending}
+            className="user-menu__item user-menu__item--danger"
+          >
+            <LogOut size={16} />
+            Logout
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/contexts/SettingsContext.tsx
+++ b/frontend/src/contexts/SettingsContext.tsx
@@ -1,0 +1,42 @@
+import { createContext, useContext, useEffect, useState } from 'react';
+
+type AppSettings = {
+  requireSummaryOnSave: boolean;
+};
+
+interface SettingsContextValue {
+  requireSummaryOnSave: boolean;
+  setRequireSummaryOnSave: (value: boolean) => void;
+}
+
+const SettingsContext = createContext<SettingsContextValue | null>(null);
+
+function isSummaryRequired(): boolean {
+  return localStorage.getItem('require-summary') === 'true';
+}
+
+export function SettingsProvider({ children }: { children: React.ReactNode }) {
+  const [settings, setSettings] = useState<AppSettings>({
+    requireSummaryOnSave: isSummaryRequired(),
+  });
+
+  useEffect(() => {
+    localStorage.setItem('require-summary', String(settings.requireSummaryOnSave));
+  }, [settings]);
+
+  const setRequireSummaryOnSave = (value: boolean) => {
+    setSettings((prev) => ({ ...prev, requireSummaryOnSave: value }));
+  };
+
+  return (
+    <SettingsContext.Provider value={{ requireSummaryOnSave: settings.requireSummaryOnSave, setRequireSummaryOnSave }}>
+      {children}
+    </SettingsContext.Provider>
+  );
+}
+
+export function useSettings() {
+  const ctx = useContext(SettingsContext);
+  if (!ctx) throw new Error('useSettings must be used inside <SettingsProvider>');
+  return ctx;
+}

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -5,6 +5,7 @@ import 'bootstrap/dist/css/bootstrap.min.css';
 import './style/index.css';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { ThemeProvider } from './contexts/ThemeContext';
+import { SettingsProvider } from './contexts/SettingsContext';
 import { AuthProvider } from './contexts/AuthContext';
 
 if (import.meta.env.DEV) {
@@ -31,7 +32,9 @@ root.render(
   <QueryClientProvider client={queryClient}>
     <AuthProvider>
       <ThemeProvider>
-        <App />
+        <SettingsProvider>
+          <App />
+        </SettingsProvider>
       </ThemeProvider>
     </AuthProvider>
   </QueryClientProvider>,

--- a/frontend/src/style/index.css
+++ b/frontend/src/style/index.css
@@ -296,3 +296,152 @@ body {
 .dark .author-select__option--is-focused {
   background-color: #334155 !important;
 }
+
+/* User menu dropdown */
+.user-menu__trigger {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.5rem;
+  height: 2.5rem;
+  border-radius: 9999px;
+  border: 1px solid #cbd5e1;
+  background-color: #f1f5f9;
+  padding: 0;
+  color: #334155;
+  transition:
+    background-color 0.15s,
+    border-color 0.15s,
+    color 0.15s;
+}
+
+.user-menu__trigger:hover {
+  background-color: #e2e8f0;
+}
+
+.user-menu__trigger--open {
+  background-color: #e2e8f0;
+  color: #1e293b;
+}
+
+.user-menu__icon {
+  color: #64748b;
+}
+
+.user-menu__header {
+  padding: 0.625rem 0.75rem 0.5rem;
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: #1e293b;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.user-menu__panel {
+  position: absolute;
+  right: 0;
+  z-index: 30;
+  margin-top: 0.5rem;
+  min-width: 11rem;
+  overflow: hidden;
+  border-radius: 0.5rem;
+  border: 1px solid #e2e8f0;
+  background-color: #ffffff;
+  box-shadow:
+    0 10px 15px -3px rgb(0 0 0 / 0.1),
+    0 4px 6px -4px rgb(0 0 0 / 0.1);
+}
+
+.user-menu__item {
+  display: flex;
+  width: 100%;
+  align-items: center;
+  gap: 0.5rem;
+  border: 0;
+  background-color: transparent;
+  padding: 0.5rem 0.75rem;
+  text-align: left;
+  font-size: 0.875rem;
+  color: #334155;
+  transition:
+    background-color 0.15s,
+    color 0.15s;
+}
+
+.user-menu__item:hover:not(:disabled) {
+  background-color: #f1f5f9;
+  color: #1e293b;
+}
+
+.user-menu__item:disabled {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
+.user-menu__item--danger {
+  color: #dc2626;
+}
+
+.user-menu__item--danger:hover:not(:disabled) {
+  background-color: #fef2f2;
+  color: #b91c1c;
+}
+
+.user-menu__divider {
+  border-top: 1px solid #f1f5f9;
+}
+
+.dark .user-menu__trigger {
+  border-color: #475569;
+  background-color: #1e293b;
+  color: #e2e8f0;
+}
+
+.dark .user-menu__trigger:hover {
+  background-color: #334155;
+}
+
+.dark .user-menu__trigger--open {
+  border-color: #64748b;
+  background-color: #334155;
+  color: #f1f5f9;
+}
+
+.dark .user-menu__icon {
+  color: #94a3b8;
+}
+
+.dark .user-menu__header {
+  color: #f1f5f9;
+}
+
+.dark .user-menu__panel {
+  border-color: #334155;
+  background-color: #1e293b;
+  box-shadow:
+    0 10px 15px -3px rgb(0 0 0 / 0.4),
+    0 4px 6px -4px rgb(0 0 0 / 0.4);
+}
+
+.dark .user-menu__item {
+  color: #e2e8f0;
+}
+
+.dark .user-menu__item:hover:not(:disabled) {
+  background-color: #334155;
+  color: #f8fafc;
+}
+
+.dark .user-menu__item--danger {
+  color: #f87171;
+}
+
+.dark .user-menu__item--danger:hover:not(:disabled) {
+  background-color: rgb(127 29 29 / 0.4);
+  color: #fca5a5;
+}
+
+.dark .user-menu__divider {
+  border-top-color: #334155;
+}

--- a/frontend/src/style/index.css
+++ b/frontend/src/style/index.css
@@ -445,3 +445,63 @@ body {
 .dark .user-menu__divider {
   border-top-color: #334155;
 }
+
+.user-menu__toggle-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  padding: 0.5rem 0.75rem;
+}
+
+.user-menu__toggle-label {
+  margin: 0;
+  font-size: 0.8125rem;
+  line-height: 1.25;
+  color: #334155;
+  cursor: pointer;
+}
+
+.user-menu__switch {
+  position: relative;
+  flex-shrink: 0;
+  width: 2.25rem;
+  height: 1.25rem;
+  border: 0;
+  border-radius: 9999px;
+  background-color: #cbd5e1;
+  padding: 0;
+  cursor: pointer;
+  transition: background-color 0.15s;
+}
+
+.user-menu__switch--on {
+  background-color: #4f46e5;
+}
+
+.user-menu__switch-thumb {
+  position: absolute;
+  top: 0.125rem;
+  left: 0.125rem;
+  width: 1rem;
+  height: 1rem;
+  border-radius: 9999px;
+  background-color: #ffffff;
+  transition: transform 0.15s;
+}
+
+.user-menu__switch--on .user-menu__switch-thumb {
+  transform: translateX(1rem);
+}
+
+.dark .user-menu__toggle-label {
+  color: #e2e8f0;
+}
+
+.dark .user-menu__switch {
+  background-color: #475569;
+}
+
+.dark .user-menu__switch--on {
+  background-color: #6366f1;
+}


### PR DESCRIPTION
## Description
This PR adds a user menu as well as a new setting where user can choose if the summary should be required for articles.

## Changes
- Add an user menu on the top right of the UI to gather user's settings.
- Move theme and log out buttons there.
- Add a setting to force user to write a summary when adding/editing an article with `read=true`.
- Share this setting through a context.

Closes #24 