### PR TITLE
feat(frontend): add loading states to grid and stats pages

### DIFF
--- a/frontend/src/components/pages/GridPage.tsx
+++ b/frontend/src/components/pages/GridPage.tsx
@@ -16,7 +16,14 @@ interface GridPageProps {
 }
 
 function GridPage({ title, description, emptyMessage, filter, badge, clearPatch, cardAction }: Readonly<GridPageProps>) {
-  const { data: { articles = [] } = {}, error } = useArticles();
+  const { data: { articles = [] } = {}, error, isLoading,} = useArticles();
+if (isLoading) {
+  return (
+    <div className="rounded-2xl border border-slate-200/80 bg-white/90 p-6 text-slate-600 shadow-sm dark:border-slate-700 dark:bg-slate-800/80 dark:text-slate-300">
+      Loading articles...
+    </div>
+  );
+}
   const filtered = articles.filter(filter);
 
   return (

--- a/frontend/src/components/pages/StatsPage.tsx
+++ b/frontend/src/components/pages/StatsPage.tsx
@@ -12,8 +12,14 @@ type ReadByMonthStat = {
 };
 
 function StatsPage() {
-  const { data: { articles = [] } = {} } = useArticles();
-  const { data: topAuthors = [] } = useTopAuthors();
+ const {
+  data: { articles = [] } = {},
+  isLoading: isArticlesLoading,
+} = useArticles();
+const {
+  data: topAuthors = [],
+  isLoading: isAuthorsLoading,
+} = useTopAuthors();
   const isDarkMode = useIsDarkMode();
   const axisColor = isDarkMode ? '#cbd5e1' : '#475569';
   const gridColor = isDarkMode ? '#334155' : '#e2e8f0';
@@ -23,6 +29,13 @@ function StatsPage() {
     borderRadius: '0.75rem',
     color: isDarkMode ? '#e2e8f0' : '#0f172a',
   };
+  if (isArticlesLoading || isAuthorsLoading) {
+  return (
+    <div className="rounded-2xl border border-slate-200/80 bg-white/90 p-6 text-slate-600 shadow-sm dark:border-slate-700 dark:bg-slate-800/80 dark:text-slate-300">
+      Loading statistics...
+    </div>
+  );
+}
 
   const readPerMonth = useMemo<ReadByMonthStat[]>(() => {
     const counts = new Map<string, ReadByMonthStat>();

--- a/frontend/src/components/pages/StatsPage.tsx
+++ b/frontend/src/components/pages/StatsPage.tsx
@@ -29,13 +29,7 @@ const {
     borderRadius: '0.75rem',
     color: isDarkMode ? '#e2e8f0' : '#0f172a',
   };
-  if (isArticlesLoading || isAuthorsLoading) {
-  return (
-    <div className="rounded-2xl border border-slate-200/80 bg-white/90 p-6 text-slate-600 shadow-sm dark:border-slate-700 dark:bg-slate-800/80 dark:text-slate-300">
-      Loading statistics...
-    </div>
-  );
-}
+
 
   const readPerMonth = useMemo<ReadByMonthStat[]>(() => {
     const counts = new Map<string, ReadByMonthStat>();
@@ -73,7 +67,13 @@ const {
   }, [articles]);
 
   const consultedCount = articles.filter((article) => article.consulted).length;
-
+  if (isArticlesLoading || isAuthorsLoading) {
+  return (
+    <div className="rounded-2xl border border-slate-200/80 bg-white/90 p-6 text-slate-600 shadow-sm dark:border-slate-700 dark:bg-slate-800/80 dark:text-slate-300">
+      Loading statistics...
+    </div>
+  );
+}
   return (
     <div className="space-y-5">
       <PageHeader title="Stats" description="Understand reading trends across your article collection.">


### PR DESCRIPTION
mmary

Adds loading states to pages that previously could not differentiate between data being fetched and no data being available.

Changes
Added loading state handling in GridPage.tsx
Affects:
Likes page
Read Later page
Added loading state handling in StatsPage.tsx
Affects:
Stats page
Result

Users now see a loading message while data is being fetched instead of immediately seeing empty-state messages, improving clarity and responsiveness of the UI.