### PR TITLE
fix(backend): cap pagination limit to 1000 server-side

### DIFF
--- a/backend/src/app/decorators.py
+++ b/backend/src/app/decorators.py
@@ -26,6 +26,7 @@ def get_user_id(fn):
 
     return wrapper
 
+MAX_LIMIT = 1000
 
 def get_pagination(fn):
     @wraps(fn)
@@ -36,6 +37,8 @@ def get_pagination(fn):
             raise BadRequest("Offset should be greater than or equal to 0.")
         if limit is not None and limit <= 0:
             raise BadRequest("Limit should be greater than 0.")
+        if limit is not None and limit > MAX_LIMIT:                          # 👈 new
+            raise BadRequest(f"Limit should not exceed {MAX_LIMIT}.")        # 👈 new
         return fn(*args, offset=offset, limit=limit, **kwargs)
 
     return wrapper

--- a/backend/src/tests/test_api.py
+++ b/backend/src/tests/test_api.py
@@ -145,3 +145,8 @@ def test_list_articles_rejects_negative_offset(auth_client):
 def test_list_articles_rejects_zero_limit(auth_client):
     res = auth_client.get("/articles?offset=0&limit=0")
     assert res.status_code == 400
+
+def test_list_articles_rejects_limit_above_max(auth_client):
+    res = auth_client.get("/articles?limit=1001")
+    assert res.status_code == 400
+    assert "1000" in res.get_json()["error"]    


### PR DESCRIPTION
Closes #79
Added a MAX_LIMIT = 1000 cap in the get_pagination decorator. If the requested limit exceeds 1000, the request is rejected with a 400 Bad Request and an explicit error message.
Changes:

decorators.py — added max limit check
test_api.py — added test_list_articles_rejects_limit_above_max