### PR TITLE
feat(frontend): add export as csv

### DIFF
--- a/frontend/src/components/features/EditButton.tsx
+++ b/frontend/src/components/features/EditButton.tsx
@@ -18,7 +18,7 @@ function EditButton({ activeItem }: Readonly<PropsType>) {
   }
 
   return (
-    <div className="flex justify-end">
+    <div className="flex justify-center">
       <button
         onClick={toggleModal}
         className="rounded-lg p-1.5 text-emerald-600 transition hover:bg-emerald-50 hover:text-emerald-700"

--- a/frontend/src/components/layout/DataTable.tsx
+++ b/frontend/src/components/layout/DataTable.tsx
@@ -49,8 +49,6 @@ function DataTable({ rows, columns, isFetching, error, total, paginationModel, s
         slots={{ toolbar: GridToolbar }}
         slotProps={{
           toolbar: {
-            printOptions: { disableToolbarButton: false },
-            csvOptions: { disableToolbarButton: true },
             showQuickFilter: true,
           },
         }}

--- a/frontend/src/components/layout/DataTable.tsx
+++ b/frontend/src/components/layout/DataTable.tsx
@@ -1,4 +1,4 @@
-import { DataGrid, GridColDef, GridToolbar } from '@mui/x-data-grid';
+import { DataGrid, GridColDef } from '@mui/x-data-grid';
 
 import { Article } from '../../constants/types';
 import { useIsDarkMode } from '../../contexts/ThemeContext';
@@ -46,7 +46,6 @@ function DataTable({ rows, columns, isFetching, error, total, paginationModel, s
         disableColumnFilter
         disableColumnSelector
         disableDensitySelector
-        slots={{ toolbar: GridToolbar }}
         slotProps={{
           toolbar: {
             showQuickFilter: true,

--- a/frontend/src/components/pages/ArticlesPage.tsx
+++ b/frontend/src/components/pages/ArticlesPage.tsx
@@ -17,12 +17,11 @@ export default function ArticlesPage() {
     pageSize: 25,
   });
   const { data: { articles = [], total = 0 } = {}, isFetching, error } = useArticles(paginationModel.page, paginationModel.pageSize);
-
-  const TITLE_ADD_FORM: string = 'Add article';
   const COLUMNS: GridColDef[] = [
     {
       field: 'title',
-      width: 300,
+      flex: 1,
+      minWidth: 200,
       renderHeader: () => <strong className="fs-5">{'Title'}</strong>,
       renderCell: (params) => (
         <ArticleLink
@@ -58,17 +57,23 @@ export default function ArticlesPage() {
     {
       field: 'consulted',
       width: 120,
+      align: 'center',
+      headerAlign: 'center',
       renderHeader: () => <strong className="fs-5">{'Consulted'}</strong>,
       renderCell: (params) => <StatusIcon active={params.row.consulted} />,
     },
     {
       field: 'read_later',
       width: 120,
+      align: 'center',
+      headerAlign: 'center',
       renderHeader: () => <strong className="fs-5">{'Read later'}</strong>,
       renderCell: (params) => <StatusIcon active={params.row.read_later} />,
     },
     {
       field: 'liked',
+      align: 'center',
+      headerAlign: 'center',
       renderHeader: () => <strong className="fs-5">{'Liked'}</strong>,
       renderCell: (params) => (
         <span
@@ -84,13 +89,10 @@ export default function ArticlesPage() {
     },
     {
       field: 'actions',
-      headerName: 'Actions',
+      align: 'center',
+      headerAlign: 'center',
       renderHeader: () => <strong className="fs-5">{'Edit'}</strong>,
-      renderCell: (params) => (
-        <div className="d-flex justify-content-center align-items-center">
-          <EditButton activeItem={params.row} />
-        </div>
-      ),
+      renderCell: (params) => <EditButton activeItem={params.row} />,
     },
   ];
 
@@ -103,7 +105,7 @@ export default function ArticlesPage() {
       </PageHeader>
 
       <div className="flex justify-end">
-        <AddButton title={TITLE_ADD_FORM} />
+        <AddButton title={'Add article'} />
       </div>
 
       <div className="overflow-hidden rounded-2xl border border-slate-200/80 bg-white shadow-sm dark:border-slate-700 dark:bg-slate-800">

--- a/frontend/src/style/index.css
+++ b/frontend/src/style/index.css
@@ -58,7 +58,8 @@ body {
   padding-bottom: 0.5rem;
 }
 
-.app-data-grid .MuiDataGrid-toolbarContainer {
+.app-data-grid .MuiDataGrid-toolbarContainer,
+.app-data-grid .MuiDataGrid-toolbar {
   border-bottom: 1px solid #e2e8f0;
   padding: 0.5rem 0.75rem;
   background-color: #ffffff;
@@ -73,6 +74,7 @@ body {
 .dark .app-data-grid .MuiDataGrid-overlayWrapperInner,
 .dark .app-data-grid .MuiDataGrid-overlay,
 .dark .app-data-grid .MuiDataGrid-filler,
+.dark .app-data-grid .MuiDataGrid-toolbar,
 .dark .app-data-grid .MuiDataGrid-footerContainer {
   background-color: #0f172a !important;
   color: #e2e8f0 !important;
@@ -107,37 +109,44 @@ body {
   border-bottom-color: #334155;
 }
 
-.dark .app-data-grid .MuiDataGrid-toolbarContainer {
+.dark .app-data-grid .MuiDataGrid-toolbarContainer,
+.dark .app-data-grid .MuiDataGrid-toolbar {
   border-bottom-color: #334155;
   background-color: #0f172a;
   color: #cbd5e1;
 }
 
-.dark .app-data-grid .MuiDataGrid-toolbarContainer .MuiInputBase-root {
+.dark .app-data-grid .MuiDataGrid-toolbarContainer .MuiInputBase-root,
+.dark .app-data-grid .MuiDataGrid-toolbar .MuiInputBase-root {
   color: #e2e8f0;
   background-color: #1e293b;
   border: 1px solid #334155;
   border-radius: 0.5rem;
 }
 
-.dark .app-data-grid .MuiDataGrid-toolbarContainer .MuiInputBase-input {
+.dark .app-data-grid .MuiDataGrid-toolbarContainer .MuiInputBase-input,
+.dark .app-data-grid .MuiDataGrid-toolbar .MuiInputBase-input {
   color: #e2e8f0;
 }
 
-.dark .app-data-grid .MuiDataGrid-toolbarContainer .MuiInputBase-input::placeholder {
+.dark .app-data-grid .MuiDataGrid-toolbarContainer .MuiInputBase-input::placeholder,
+.dark .app-data-grid .MuiDataGrid-toolbar .MuiInputBase-input::placeholder {
   color: #94a3b8;
   opacity: 1;
 }
 
-.dark .app-data-grid .MuiDataGrid-toolbarContainer .MuiSvgIcon-root {
+.dark .app-data-grid .MuiDataGrid-toolbarContainer .MuiSvgIcon-root,
+.dark .app-data-grid .MuiDataGrid-toolbar .MuiSvgIcon-root {
   color: #94a3b8;
 }
 
-.dark .app-data-grid .MuiDataGrid-toolbarContainer .MuiButtonBase-root {
+.dark .app-data-grid .MuiDataGrid-toolbarContainer .MuiButtonBase-root,
+.dark .app-data-grid .MuiDataGrid-toolbar .MuiButtonBase-root {
   color: #cbd5e1;
 }
 
-.dark .app-data-grid .MuiDataGrid-toolbarContainer .MuiButtonBase-root:hover {
+.dark .app-data-grid .MuiDataGrid-toolbarContainer .MuiButtonBase-root:hover,
+.dark .app-data-grid .MuiDataGrid-toolbar .MuiButtonBase-root:hover {
   background-color: #1e293b;
 }
 


### PR DESCRIPTION
## Description
This PR adds the ability to export the articles table as CSV.

The original issue also mentioned exporting as JSON. The [Data Grid doc](https://mui.com/x/react-data-grid/export/#custom-export-format) explains how to do this. However, it requires to add a significant amount of code. As long as this feature is just a nice addition and not a real benefit, not worth it to implement.

## Changes
- Updated `slotProps.toolbar` to configure export options.
- Remove deprecated 'GridToolbar' and replace by new API.
- Update styling of table's toolbar and columns.

Closes #26 