### PR TITLE
Manage filtering server-side to fix regression due to pagination

### DIFF
--- a/backend/src/app/__init__.py
+++ b/backend/src/app/__init__.py
@@ -14,6 +14,7 @@ from app.blueprints.articles import articles_bp
 from app.blueprints.auth import auth_bp
 from app.blueprints.authors import authors_bp
 from app.blueprints.health import health_bp
+from app.blueprints.search import search_bp
 from app.blueprints.tags import tags_bp
 from app.database import db
 from app.exceptions import EntitiesNotFoundError, EntityDuplicatedError
@@ -114,6 +115,7 @@ def create_app(test_config=None):
     app.register_blueprint(articles_bp)
     app.register_blueprint(authors_bp)
     app.register_blueprint(tags_bp)
+    app.register_blueprint(search_bp)
 
     logger.info("App created — blueprints registered, DB ready")
     return app

--- a/backend/src/app/blueprints/articles.py
+++ b/backend/src/app/blueprints/articles.py
@@ -27,7 +27,7 @@ logger = logging.getLogger("article_manager.articles")
 articles_bp = Blueprint("articles", __name__, url_prefix="/articles")
 
 
-@articles_bp.route("")
+@articles_bp.route("", methods=["GET"])
 @jwt_required()
 @get_user_id
 @get_pagination
@@ -57,7 +57,7 @@ def list_articles(user_id: int, offset: int | None = None, limit: int | None = N
     ), 200
 
 
-@articles_bp.route("/<int:article_id>")
+@articles_bp.route("/<int:article_id>", methods=["GET"])
 @jwt_required()
 @get_user_id
 def get_article(user_id: int, article_id: int):

--- a/backend/src/app/blueprints/search.py
+++ b/backend/src/app/blueprints/search.py
@@ -2,11 +2,11 @@ import logging
 
 from flask import Blueprint, jsonify, request
 from flask_jwt_extended import jwt_required
-from sqlalchemy import String, cast, or_, select
+from sqlalchemy import String, cast, func, or_, select
 from werkzeug.exceptions import BadRequest
 
 from app.database import db
-from app.decorators import get_user_id
+from app.decorators import get_pagination, get_user_id
 from app.models import Article, Author
 
 logger = logging.getLogger("article_manager.search")
@@ -17,7 +17,8 @@ search_bp = Blueprint("search", __name__, url_prefix="/search")
 @search_bp.route("", methods=["GET"])
 @jwt_required()
 @get_user_id
-def search(user_id: int):
+@get_pagination
+def search(user_id: int, offset: int | None = None, limit: int | None = None):
     query = request.args.get("q", "").strip()
 
     if not query:
@@ -37,7 +38,31 @@ def search(user_id: int):
         )
         .order_by(Article.date_modification.desc(), Article.id.desc())
     )
+    if offset is not None:
+        stmt = stmt.offset(offset)
+    if limit is not None:
+        stmt = stmt.limit(limit)
     articles = db.session.execute(stmt).scalars().all()
+    logger.debug(
+        "Listed %d articles for user_id=%d with filter=%s",
+        len(articles),
+        user_id,
+        query,
+    )
+    count_stmt = (
+        select(func.count())
+        .select_from(Article)
+        .join(Article.author)
+        .where(Article.user_id == user_id)
+        .where(
+            or_(
+                Article.title.ilike(pattern),
+                cast(Article.year, String).ilike(pattern),
+                Author.name.ilike(pattern),
+            )
+        )
+    )
+    total = db.session.execute(count_stmt).scalar_one()
     return jsonify(
-        {"data": [article.to_dict() for article in articles], "total": len(articles)}
+        {"data": [article.to_dict() for article in articles], "total": total}
     ), 200

--- a/backend/src/app/blueprints/search.py
+++ b/backend/src/app/blueprints/search.py
@@ -39,8 +39,5 @@ def search(user_id: int):
     )
     articles = db.session.execute(stmt).scalars().all()
     return jsonify(
-        {
-            "data": [article.to_dict() for article in articles],
-            "total": len(articles),
-        }
+        {"data": [article.to_dict() for article in articles], "total": len(articles)}
     ), 200

--- a/backend/src/app/blueprints/search.py
+++ b/backend/src/app/blueprints/search.py
@@ -1,0 +1,46 @@
+import logging
+
+from flask import Blueprint, jsonify, request
+from flask_jwt_extended import jwt_required
+from sqlalchemy import String, cast, or_, select
+from werkzeug.exceptions import BadRequest
+
+from app.database import db
+from app.decorators import get_user_id
+from app.models import Article, Author
+
+logger = logging.getLogger("article_manager.search")
+
+search_bp = Blueprint("search", __name__, url_prefix="/search")
+
+
+@search_bp.route("", methods=["GET"])
+@jwt_required()
+@get_user_id
+def search(user_id: int):
+    query = request.args.get("q", "").strip()
+
+    if not query:
+        raise BadRequest("Invalid query")
+
+    pattern = f"%{query}%"
+    stmt = (
+        select(Article)
+        .join(Article.author)
+        .where(Article.user_id == user_id)
+        .where(
+            or_(
+                Article.title.ilike(pattern),
+                cast(Article.year, String).ilike(pattern),
+                Author.name.ilike(pattern),
+            )
+        )
+        .order_by(Article.date_modification.desc(), Article.id.desc())
+    )
+    articles = db.session.execute(stmt).scalars().all()
+    return jsonify(
+        {
+            "data": [article.to_dict() for article in articles],
+            "total": len(articles),
+        }
+    ), 200

--- a/backend/src/tests/test_filter.py
+++ b/backend/src/tests/test_filter.py
@@ -1,0 +1,26 @@
+import pytest
+
+
+@pytest.mark.parametrize(
+    "query, result", [("sanderson", 2), ("SANDERS", 2), ("moloch", 1), ("2019", 1)]
+)
+def test_filter(auth_client, create_list_authors_articles, query, result):
+    res = auth_client.get("/articles")
+    assert res.status_code == 200
+    payload = res.get_json()["data"]
+    assert len(payload) == 6
+
+    res2 = auth_client.get(f"/search?q={query}")
+    assert res2.status_code == 200
+    payload2 = res2.get_json()["data"]
+    assert len(payload2) == result
+
+
+def test_missing_query(auth_client):
+    res = auth_client.get("/search")
+    assert res.status_code == 400
+
+
+def test_empty_query(auth_client):
+    res = auth_client.get("/search?q=")
+    assert res.status_code == 400

--- a/frontend/src/api/entities.ts
+++ b/frontend/src/api/entities.ts
@@ -154,8 +154,11 @@ export const articlesApi = {
     const response = parseWithError(ParsedMetadataSchema, data);
     return response;
   },
-  search: async (query: string): Promise<{ articles: Article[]; total: number }> => {
-    const encodedQuery = encodeURIComponent(query);
+  search: async (query: string, offset: number, limit: number): Promise<{ articles: Article[]; total: number }> => {
+    let encodedQuery = encodeURIComponent(query);
+    if (offset != undefined && limit != undefined) {
+      encodedQuery = `${encodedQuery}&offset=${offset}&limit=${limit}`;
+    }
     const { data } = await apiClient.get(`${API_URLS.SEARCH}?q=${encodedQuery}`);
     const response = parseWithError(ArticlesSchema, data);
     const articles = response['data'];

--- a/frontend/src/api/entities.ts
+++ b/frontend/src/api/entities.ts
@@ -154,6 +154,13 @@ export const articlesApi = {
     const response = parseWithError(ParsedMetadataSchema, data);
     return response;
   },
+  search: async (query: string): Promise<{ articles: Article[]; total: number }> => {
+    const { data } = await apiClient.get(`${API_URLS.SEARCH}?q=${query}`);
+    const response = parseWithError(ArticlesSchema, data);
+    const articles = response['data'];
+    const total = response['total'];
+    return { articles, total };
+  },
 };
 
 export const authorsApi = {

--- a/frontend/src/api/entities.ts
+++ b/frontend/src/api/entities.ts
@@ -155,7 +155,8 @@ export const articlesApi = {
     return response;
   },
   search: async (query: string): Promise<{ articles: Article[]; total: number }> => {
-    const { data } = await apiClient.get(`${API_URLS.SEARCH}?q=${query}`);
+    const encodedQuery = encodeURIComponent(query);
+    const { data } = await apiClient.get(`${API_URLS.SEARCH}?q=${encodedQuery}`);
     const response = parseWithError(ArticlesSchema, data);
     const articles = response['data'];
     const total = response['total'];

--- a/frontend/src/api/queryKeys.ts
+++ b/frontend/src/api/queryKeys.ts
@@ -4,6 +4,7 @@ export const queryKeys = {
     list: () => [...queryKeys.articles.all, 'list'],
     slice: (page: number, pageSize: number) => [...queryKeys.articles.all, page, pageSize],
     detail: (id: number) => [...queryKeys.articles.all, 'detail', id],
+    search: (query: string) => [...queryKeys.articles.all, 'search', query],
   },
   tags: {
     all: ['tags'],

--- a/frontend/src/api/queryKeys.ts
+++ b/frontend/src/api/queryKeys.ts
@@ -4,7 +4,7 @@ export const queryKeys = {
     list: () => [...queryKeys.articles.all, 'list'],
     slice: (page: number, pageSize: number) => [...queryKeys.articles.all, page, pageSize],
     detail: (id: number) => [...queryKeys.articles.all, 'detail', id],
-    search: (query: string) => [...queryKeys.articles.all, 'search', query],
+    search: (query: string, page: number, pageSize: number) => [...queryKeys.articles.all, 'search', query, page, pageSize],
   },
   tags: {
     all: ['tags'],

--- a/frontend/src/components/layout/DataTable.tsx
+++ b/frontend/src/components/layout/DataTable.tsx
@@ -2,6 +2,7 @@ import { useCallback } from 'react';
 
 import { DataGrid, GridColDef, GridFilterModel } from '@mui/x-data-grid';
 
+import { pageSize } from '../../constants/constants';
 import { Article } from '../../constants/types';
 import { useIsDarkMode } from '../../contexts/ThemeContext';
 import { ErrorMessage } from '../features/ErrorMessage';
@@ -30,6 +31,7 @@ function DataTable({ rows, columns, isFetching, error, total, paginationModel, s
 
   const onFilterChange = useCallback((filterModel: GridFilterModel) => {
     setSearch(filterModel?.quickFilterValues?.[0] || '');
+    setPaginationModel({ page: 0, pageSize: pageSize });
   }, []);
 
   if (error) {

--- a/frontend/src/components/layout/DataTable.tsx
+++ b/frontend/src/components/layout/DataTable.tsx
@@ -1,4 +1,6 @@
-import { DataGrid, GridColDef } from '@mui/x-data-grid';
+import { useCallback } from 'react';
+
+import { DataGrid, GridColDef, GridFilterModel } from '@mui/x-data-grid';
 
 import { Article } from '../../constants/types';
 import { useIsDarkMode } from '../../contexts/ThemeContext';
@@ -20,10 +22,15 @@ interface DataTableProps {
       pageSize: number;
     }>
   >;
+  setSearch: React.Dispatch<React.SetStateAction<string>>;
 }
 
-function DataTable({ rows, columns, isFetching, error, total, paginationModel, setPaginationModel }: Readonly<DataTableProps>) {
+function DataTable({ rows, columns, isFetching, error, total, paginationModel, setPaginationModel, setSearch }: Readonly<DataTableProps>) {
   const isDarkMode = useIsDarkMode();
+
+  const onFilterChange = useCallback((filterModel: GridFilterModel) => {
+    setSearch(filterModel?.quickFilterValues?.[0] || '');
+  }, []);
 
   if (error) {
     return ErrorMessage(error.message);
@@ -36,6 +43,8 @@ function DataTable({ rows, columns, isFetching, error, total, paginationModel, s
         rows={rows}
         columns={columns}
         loading={isFetching}
+        filterMode="server"
+        onFilterModelChange={onFilterChange}
         paginationMode="server"
         paginationModel={paginationModel}
         onPaginationModelChange={setPaginationModel}

--- a/frontend/src/components/layout/DataTable.tsx
+++ b/frontend/src/components/layout/DataTable.tsx
@@ -26,13 +26,25 @@ interface DataTableProps {
   setSearch: React.Dispatch<React.SetStateAction<string>>;
 }
 
-function DataTable({ rows, columns, isFetching, error, total, paginationModel, setPaginationModel, setSearch }: Readonly<DataTableProps>) {
+export default function DataTable({
+  rows,
+  columns,
+  isFetching,
+  error,
+  total,
+  paginationModel,
+  setPaginationModel,
+  setSearch,
+}: Readonly<DataTableProps>) {
   const isDarkMode = useIsDarkMode();
 
-  const onFilterChange = useCallback((filterModel: GridFilterModel) => {
-    setSearch(filterModel?.quickFilterValues?.[0] || '');
-    setPaginationModel({ page: 0, pageSize: pageSize });
-  }, []);
+  const onFilterChange = useCallback(
+    (filterModel: GridFilterModel) => {
+      setSearch(filterModel?.quickFilterValues?.[0] || '');
+      setPaginationModel({ page: 0, pageSize: pageSize });
+    },
+    [setSearch, setPaginationModel],
+  );
 
   if (error) {
     return ErrorMessage(error.message);
@@ -80,6 +92,3 @@ function DataTable({ rows, columns, isFetching, error, total, paginationModel, s
     </div>
   );
 }
-
-// Exportation
-export default DataTable;

--- a/frontend/src/components/pages/ArticlesPage.tsx
+++ b/frontend/src/components/pages/ArticlesPage.tsx
@@ -3,7 +3,8 @@ import { Heart } from 'react-feather';
 
 import { GridColDef } from '@mui/x-data-grid';
 
-import { useArticles } from '../../hooks/queries';
+import { useArticles, useSearch } from '../../hooks/queries';
+import { useDebounce } from '../../hooks/useDebounce';
 import AddButton from '../features/AddButton';
 import { ArticleLink } from '../features/ArticleLink';
 import EditButton from '../features/EditButton';
@@ -16,7 +17,14 @@ export default function ArticlesPage() {
     page: 0,
     pageSize: 25,
   });
-  const { data: { articles = [], total = 0 } = {}, isFetching, error } = useArticles(paginationModel.page, paginationModel.pageSize);
+  const [search, setSearch] = useState('');
+  const debouncedSearchQuery = useDebounce(search.trim(), 300);
+  const isSearching = debouncedSearchQuery.length > 0;
+  const articlesQuery = useArticles(paginationModel.page, paginationModel.pageSize);
+  const searchQueryResult = useSearch(debouncedSearchQuery);
+
+  const { data: { articles = [], total = 0 } = {}, isFetching, error } = isSearching ? searchQueryResult : articlesQuery;
+
   const COLUMNS: GridColDef[] = [
     {
       field: 'title',
@@ -117,6 +125,7 @@ export default function ArticlesPage() {
           error={error}
           paginationModel={paginationModel}
           setPaginationModel={setPaginationModel}
+          setSearch={setSearch}
         />
       </div>
     </div>

--- a/frontend/src/components/pages/ArticlesPage.tsx
+++ b/frontend/src/components/pages/ArticlesPage.tsx
@@ -20,7 +20,7 @@ export default function ArticlesPage() {
   });
   const [search, setSearch] = useState('');
   const debouncedSearchQuery = useDebounce(search.trim(), 500);
-  const isSearching = debouncedSearchQuery.length > 0;
+  const isSearching = debouncedSearchQuery?.length > 0;
   const articlesQuery = useArticles(isSearching, paginationModel.page, paginationModel.pageSize);
   const searchQueryResult = useSearch(debouncedSearchQuery, paginationModel.page, paginationModel.pageSize);
   const { data: { articles = [], total = 0 } = {}, isFetching, error } = isSearching ? searchQueryResult : articlesQuery;

--- a/frontend/src/components/pages/ArticlesPage.tsx
+++ b/frontend/src/components/pages/ArticlesPage.tsx
@@ -3,6 +3,7 @@ import { Heart } from 'react-feather';
 
 import { GridColDef } from '@mui/x-data-grid';
 
+import { pageSize } from '../../constants/constants';
 import { useArticles, useSearch } from '../../hooks/queries';
 import { useDebounce } from '../../hooks/useDebounce';
 import AddButton from '../features/AddButton';
@@ -15,12 +16,12 @@ import PageHeader from '../layout/PageHeader';
 export default function ArticlesPage() {
   const [paginationModel, setPaginationModel] = useState({
     page: 0,
-    pageSize: 25,
+    pageSize: pageSize,
   });
   const [search, setSearch] = useState('');
   const debouncedSearchQuery = useDebounce(search.trim(), 500);
   const isSearching = debouncedSearchQuery.length > 0;
-  const articlesQuery = useArticles(debouncedSearchQuery, paginationModel.page, paginationModel.pageSize);
+  const articlesQuery = useArticles(isSearching, paginationModel.page, paginationModel.pageSize);
   const searchQueryResult = useSearch(debouncedSearchQuery, paginationModel.page, paginationModel.pageSize);
   const { data: { articles = [], total = 0 } = {}, isFetching, error } = isSearching ? searchQueryResult : articlesQuery;
 

--- a/frontend/src/components/pages/ArticlesPage.tsx
+++ b/frontend/src/components/pages/ArticlesPage.tsx
@@ -18,10 +18,10 @@ export default function ArticlesPage() {
     pageSize: 25,
   });
   const [search, setSearch] = useState('');
-  const debouncedSearchQuery = useDebounce(search.trim(), 300);
+  const debouncedSearchQuery = useDebounce(search.trim(), 500);
   const isSearching = debouncedSearchQuery.length > 0;
-  const articlesQuery = useArticles(paginationModel.page, paginationModel.pageSize);
-  const searchQueryResult = useSearch(debouncedSearchQuery);
+  const articlesQuery = useArticles(debouncedSearchQuery, paginationModel.page, paginationModel.pageSize);
+  const searchQueryResult = useSearch(debouncedSearchQuery, paginationModel.page, paginationModel.pageSize);
   const { data: { articles = [], total = 0 } = {}, isFetching, error } = isSearching ? searchQueryResult : articlesQuery;
 
   const COLUMNS: GridColDef[] = [

--- a/frontend/src/components/pages/ArticlesPage.tsx
+++ b/frontend/src/components/pages/ArticlesPage.tsx
@@ -22,7 +22,6 @@ export default function ArticlesPage() {
   const isSearching = debouncedSearchQuery.length > 0;
   const articlesQuery = useArticles(paginationModel.page, paginationModel.pageSize);
   const searchQueryResult = useSearch(debouncedSearchQuery);
-
   const { data: { articles = [], total = 0 } = {}, isFetching, error } = isSearching ? searchQueryResult : articlesQuery;
 
   const COLUMNS: GridColDef[] = [

--- a/frontend/src/constants/constants.ts
+++ b/frontend/src/constants/constants.ts
@@ -3,6 +3,7 @@ const baseURL: string = import.meta.env.VITE_API_BASE_URL ?? 'http://localhost:5
 export const API_URLS = {
   ARTICLES: `${baseURL}/articles`,
   PARSE: `${baseURL}/articles/metadata`,
+  SEARCH: `${baseURL}/search`,
   AUTHORS: `${baseURL}/authors`,
   TOP_AUTHORS: `${baseURL}/authors/top`,
   TAGS: `${baseURL}/tags`,

--- a/frontend/src/constants/constants.ts
+++ b/frontend/src/constants/constants.ts
@@ -31,3 +31,5 @@ export const buttonSize = {
   medium: 'w-32 h-16 text-md',
   large: 'w-40 h-20 text-lg',
 };
+
+export const pageSize = 25;

--- a/frontend/src/constants/schema.ts
+++ b/frontend/src/constants/schema.ts
@@ -48,8 +48,8 @@ export const ArticleWithContent = ArticleSchema.extend({
 export const ArticlesSchema = z.object({
   data: z.array(ArticleSchema),
   total: z.int().min(0),
-  offset: z.int().min(0).nullable(),
-  limit: z.int().min(0).nullable(),
+  offset: z.optional(z.int().min(0).nullable()),
+  limit: z.optional(z.int().min(0).nullable()),
 });
 
 export const ParsedMetadataSchema = z.object({

--- a/frontend/src/hooks/queries.ts
+++ b/frontend/src/hooks/queries.ts
@@ -3,7 +3,7 @@ import { keepPreviousData, useQuery } from '@tanstack/react-query';
 import { articlesApi, authApi, authorsApi, healthApi, tagsApi } from '../api/entities';
 import { queryKeys } from '../api/queryKeys';
 
-export function useArticles(isSearching: boolean, page?: number, pageSize?: number) {
+export function useArticles(isSearching?: boolean, page?: number, pageSize?: number) {
   return useQuery({
     queryKey: page != undefined && pageSize != undefined ? queryKeys.articles.slice(page, pageSize) : queryKeys.articles.list(),
     queryFn: async () => {

--- a/frontend/src/hooks/queries.ts
+++ b/frontend/src/hooks/queries.ts
@@ -3,7 +3,7 @@ import { keepPreviousData, useQuery } from '@tanstack/react-query';
 import { articlesApi, authApi, authorsApi, healthApi, tagsApi } from '../api/entities';
 import { queryKeys } from '../api/queryKeys';
 
-export function useArticles(page?: number, pageSize?: number) {
+export function useArticles(query: string, page?: number, pageSize?: number) {
   return useQuery({
     queryKey: page != undefined && pageSize != undefined ? queryKeys.articles.slice(page, pageSize) : queryKeys.articles.list(),
     queryFn: async () => {
@@ -15,14 +15,19 @@ export function useArticles(page?: number, pageSize?: number) {
       return articlesApi.list(offset, limit);
     },
     placeholderData: keepPreviousData,
+    enabled: !!query || query?.length == 0,
   });
 }
 
-export function useSearch(query: string) {
+export function useSearch(query: string, page: number, pageSize: number) {
   return useQuery({
-    queryKey: queryKeys.articles.search(query),
-    queryFn: () => articlesApi.search(query),
-    enabled: query.length > 0,
+    queryKey: queryKeys.articles.search(query, page, pageSize),
+    queryFn: async () => {
+      const offset = page * pageSize;
+      const limit = pageSize;
+      return articlesApi.search(query, offset, limit);
+    },
+    enabled: query.length > 0 && page != undefined && pageSize != undefined,
   });
 }
 

--- a/frontend/src/hooks/queries.ts
+++ b/frontend/src/hooks/queries.ts
@@ -18,6 +18,14 @@ export function useArticles(page?: number, pageSize?: number) {
   });
 }
 
+export function useSearch(query: string) {
+  return useQuery({
+    queryKey: queryKeys.articles.search(query),
+    queryFn: () => articlesApi.search(query),
+    enabled: query.length > 0,
+  });
+}
+
 export function useArticle(id: number) {
   return useQuery({
     queryKey: queryKeys.articles.detail(id),

--- a/frontend/src/hooks/queries.ts
+++ b/frontend/src/hooks/queries.ts
@@ -3,7 +3,7 @@ import { keepPreviousData, useQuery } from '@tanstack/react-query';
 import { articlesApi, authApi, authorsApi, healthApi, tagsApi } from '../api/entities';
 import { queryKeys } from '../api/queryKeys';
 
-export function useArticles(query: string, page?: number, pageSize?: number) {
+export function useArticles(isSearching: boolean, page?: number, pageSize?: number) {
   return useQuery({
     queryKey: page != undefined && pageSize != undefined ? queryKeys.articles.slice(page, pageSize) : queryKeys.articles.list(),
     queryFn: async () => {
@@ -15,7 +15,7 @@ export function useArticles(query: string, page?: number, pageSize?: number) {
       return articlesApi.list(offset, limit);
     },
     placeholderData: keepPreviousData,
-    enabled: !!query || query?.length == 0,
+    enabled: !isSearching,
   });
 }
 

--- a/frontend/src/hooks/useDebounce.ts
+++ b/frontend/src/hooks/useDebounce.ts
@@ -1,0 +1,15 @@
+import { useEffect, useState } from 'react';
+
+export function useDebounce<T>(value: T, delay = 300): T {
+  const [debouncedValue, setDebouncedValue] = useState(value);
+
+  useEffect(() => {
+    const timeoutId = window.setTimeout(() => {
+      setDebouncedValue(value);
+    }, delay);
+
+    return () => window.clearTimeout(timeoutId);
+  }, [value, delay]);
+
+  return debouncedValue;
+}


### PR DESCRIPTION
## Description
This PR fixes the regression introduced by the new pagination features on `GET /articles`. It does so by filtering server-side through a new endpoint `GET /search`.

## Changes
- Add a `GET /search`.
- Update frontend's logic to manage filtering server-side.
- Add pagination to the `GET /search` endpoint.


Closes #75 