### PR TITLE
refactor(backend): offload parsing to thread pool

### DIFF
--- a/backend/src/app/services/articles.py
+++ b/backend/src/app/services/articles.py
@@ -1,3 +1,4 @@
+import asyncio
 import logging
 from collections.abc import Sequence
 
@@ -50,7 +51,8 @@ async def enrich_with_content(
 ) -> list[dict] | None:
     try:
         parser = await get_metadata(session, url, user_id)
-        return parser.get_content()
+        content = await asyncio.to_thread(parser.get_content)
+        return content
     except MetadataParsingError as error:
         logger.info(
             "Article content enrichment failed for url=%s; continuing without content",
@@ -135,7 +137,7 @@ async def get_metadata(session: DbSession, url: str, user_id: int) -> MetadataPa
     try:
         parser = MetadataParser(url)
         await parser.fetch()
-        parser.parse()
+        await asyncio.to_thread(parser.parse)
         return parser
     except httpx2.HTTPError as error:
         logger.info("Article parsing failed with url: %s", url)


### PR DESCRIPTION
## Description

This PR implements the recommendation of the asyncio investigation detailed in this issue: #100.

## Changes
- Offload the CPU-bound parsing work to the thread pool to not block the event loop.


Closes #100.